### PR TITLE
Add Community Plugin System with Echo Plugin Example

### DIFF
--- a/PLUGIN_INTEGRATION_GUIDE.md
+++ b/PLUGIN_INTEGRATION_GUIDE.md
@@ -1,0 +1,225 @@
+# Plugin Integration Guide
+
+This guide explains how to integrate the community plugin system into QryptChat's chat interface.
+
+## Overview
+
+The plugin system allows users to extend QryptChat functionality through community-contributed plugins. Users can type commands like `/help` or `/echo Hello!` in chat to interact with plugins.
+
+## Integration Steps
+
+### 1. Import Plugin Manager
+
+```javascript
+import { pluginManager } from '$lib/plugins/PluginManager.js';
+```
+
+### 2. Initialize Plugin Manager
+
+Initialize the plugin manager when your chat component mounts:
+
+```javascript
+import { onMount } from 'svelte';
+
+onMount(async () => {
+  await pluginManager.initialize();
+});
+```
+
+### 3. Process Messages
+
+Before sending a message, check if it's a plugin command:
+
+```javascript
+async function handleMessage(message) {
+  // Check if it's a plugin command
+  if (pluginManager.isPluginCommand(message)) {
+    try {
+      const response = await fetch('/api/plugins/execute', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          message,
+          context: {
+            userId: currentUser.id,
+            chatId: currentChat.id,
+            timestamp: new Date().toISOString()
+          }
+        })
+      });
+
+      const result = await response.json();
+      
+      if (result.response) {
+        // Display plugin response in chat
+        displayMessage({
+          content: result.response,
+          sender: 'Plugin',
+          type: 'plugin-response',
+          timestamp: new Date()
+        });
+        return; // Don't send as regular message
+      }
+    } catch (error) {
+      console.error('Plugin command failed:', error);
+      // Fall through to send as regular message
+    }
+  }
+
+  // Send as regular message
+  sendRegularMessage(message);
+}
+```
+
+### 4. Add Plugin Help
+
+Add a help command handler:
+
+```javascript
+async function showPluginHelp() {
+  try {
+    const response = await fetch('/api/plugins/execute');
+    const data = await response.json();
+    
+    displayMessage({
+      content: data.helpText,
+      sender: 'System',
+      type: 'help',
+      timestamp: new Date()
+    });
+  } catch (error) {
+    console.error('Failed to get plugin help:', error);
+  }
+}
+```
+
+### 5. UI Integration
+
+Add a plugins link to your navigation:
+
+```html
+<a href="/plugins" class="nav-link">
+  Plugins
+</a>
+```
+
+## Example Chat Integration
+
+Here's a complete example of integrating plugins into a chat component:
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  import { pluginManager } from '$lib/plugins/PluginManager.js';
+  
+  let messages = [];
+  let messageInput = '';
+  
+  onMount(async () => {
+    await pluginManager.initialize();
+  });
+  
+  async function sendMessage() {
+    if (!messageInput.trim()) return;
+    
+    const message = messageInput.trim();
+    messageInput = '';
+    
+    // Add user message to chat
+    messages = [...messages, {
+      content: message,
+      sender: 'You',
+      timestamp: new Date()
+    }];
+    
+    // Check for plugin commands
+    if (message.startsWith('/')) {
+      try {
+        const response = await fetch('/api/plugins/execute', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message })
+        });
+        
+        const result = await response.json();
+        
+        if (result.response) {
+          messages = [...messages, {
+            content: result.response,
+            sender: 'Plugin',
+            type: 'plugin',
+            timestamp: new Date()
+          }];
+          return;
+        }
+      } catch (error) {
+        console.error('Plugin error:', error);
+      }
+    }
+    
+    // Handle regular message...
+  }
+</script>
+
+<div class="chat-container">
+  {#each messages as message}
+    <div class="message {message.type || ''}">
+      <strong>{message.sender}:</strong>
+      {message.content}
+    </div>
+  {/each}
+</div>
+
+<input 
+  bind:value={messageInput}
+  on:keydown={(e) => e.key === 'Enter' && sendMessage()}
+  placeholder="Type a message or /help for plugins..."
+/>
+```
+
+## Plugin Commands
+
+The system automatically recognizes these patterns:
+
+- `/help` - Show all available plugin commands
+- `/echo <message>` - Echo plugin example
+- Any command starting with `/` will be checked against loaded plugins
+
+## Error Handling
+
+Always handle plugin errors gracefully:
+
+```javascript
+try {
+  const result = await pluginManager.processCommand(message);
+  if (result) {
+    // Handle plugin response
+  }
+} catch (error) {
+  console.error('Plugin error:', error);
+  // Show user-friendly error message
+}
+```
+
+## Security Considerations
+
+1. **Input Validation**: Always validate plugin inputs
+2. **Sandboxing**: Consider sandboxing plugin execution
+3. **Rate Limiting**: Implement rate limiting for plugin commands
+4. **User Permissions**: Check user permissions before executing plugins
+
+## Testing
+
+Test plugin integration with:
+
+```javascript
+// Test plugin loading
+await pluginManager.initialize();
+console.log('Loaded plugins:', pluginManager.plugins.size);
+
+// Test command processing
+const response = await pluginManager.processCommand('/help');
+console.log('Help response:', response);
+```

--- a/community-plugins/README.md
+++ b/community-plugins/README.md
@@ -1,0 +1,51 @@
+# Community Plugins
+
+This directory contains third-party plugins for QryptChat.
+
+## Plugin Structure
+
+Each plugin should be in its own directory with the following structure:
+
+```
+plugin-name/
+├── plugin.json          # Plugin metadata
+├── index.js            # Main plugin file
+└── README.md           # Plugin documentation
+```
+
+## Plugin Metadata (plugin.json)
+
+```json
+{
+  "name": "plugin-name",
+  "version": "1.0.0",
+  "description": "Plugin description",
+  "author": "Author Name",
+  "commands": [
+    {
+      "command": "/help",
+      "description": "Show plugin help"
+    }
+  ]
+}
+```
+
+## Plugin API
+
+Plugins should export a class with the following methods:
+
+```javascript
+export default class PluginName {
+  constructor() {
+    this.name = 'plugin-name';
+  }
+
+  async handleCommand(command, args, context) {
+    // Handle plugin commands
+  }
+}
+```
+
+## Available Plugins
+
+- [Echo Plugin](./echo/README.md) - Simple echo example plugin

--- a/community-plugins/echo/README.md
+++ b/community-plugins/echo/README.md
@@ -1,0 +1,37 @@
+# Echo Plugin
+
+A simple example plugin that demonstrates the QryptChat plugin system.
+
+## Description
+
+The Echo plugin repeats back any message you send to it. It's designed as a basic example to show how plugins work in QryptChat.
+
+## Commands
+
+- `/echo <message>` - Echo back the provided message
+- `/help` - Show plugin help and available commands
+
+## Usage Examples
+
+```
+/echo Hello World!
+→ Echo: Hello World!
+
+/echo This is a test message
+→ Echo: This is a test message
+
+/help
+→ Shows plugin help with available commands
+```
+
+## Installation
+
+This plugin is included as an example in the community-plugins directory. It will be automatically available when the plugin system is enabled.
+
+## Development
+
+This plugin serves as a template for creating new plugins. You can use it as a starting point for developing more complex functionality.
+
+## Author
+
+QryptChat Community

--- a/community-plugins/echo/index.js
+++ b/community-plugins/echo/index.js
@@ -1,0 +1,60 @@
+/**
+ * Echo Plugin - Simple example plugin for QryptChat
+ */
+export default class EchoPlugin {
+  constructor() {
+    this.name = 'echo';
+    this.version = '1.0.0';
+  }
+
+  /**
+   * Handle plugin commands
+   * @param {string} command - The command that was triggered
+   * @param {string[]} args - Command arguments
+   * @param {object} context - Chat context (user, chat, etc.)
+   * @returns {Promise<string>} Response message
+   */
+  async handleCommand(command, args, context) {
+    switch (command) {
+      case '/help':
+        return this.getHelp();
+      
+      case '/echo':
+        if (args.length === 0) {
+          return 'Usage: /echo <message> - Echo back your message';
+        }
+        return `Echo: ${args.join(' ')}`;
+      
+      default:
+        return `Unknown command: ${command}. Type /help for available commands.`;
+    }
+  }
+
+  /**
+   * Get plugin help text
+   * @returns {string} Help text
+   */
+  getHelp() {
+    return `**Echo Plugin v${this.version}**
+
+Available commands:
+• \`/echo <message>\` - Echo back your message
+• \`/help\` - Show this help message
+
+Example: \`/echo Hello World!\` → Echo: Hello World!`;
+  }
+
+  /**
+   * Plugin initialization (optional)
+   */
+  async initialize() {
+    console.log(`Echo plugin v${this.version} initialized`);
+  }
+
+  /**
+   * Plugin cleanup (optional)
+   */
+  async cleanup() {
+    console.log('Echo plugin cleaned up');
+  }
+}

--- a/community-plugins/echo/plugin.json
+++ b/community-plugins/echo/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "echo",
+  "version": "1.0.0",
+  "description": "Simple echo plugin that repeats your message",
+  "author": "QryptChat Community",
+  "commands": [
+    {
+      "command": "/echo",
+      "description": "Echo back the provided message"
+    },
+    {
+      "command": "/help",
+      "description": "Show echo plugin help"
+    }
+  ]
+}

--- a/src/lib/plugins/PluginManager.js
+++ b/src/lib/plugins/PluginManager.js
@@ -1,0 +1,163 @@
+/**
+ * Plugin Manager - Handles loading and executing community plugins
+ */
+export class PluginManager {
+  constructor() {
+    this.plugins = new Map();
+    this.commands = new Map();
+    this.initialized = false;
+  }
+
+  /**
+   * Initialize the plugin manager and load all plugins
+   */
+  async initialize() {
+    if (this.initialized) return;
+
+    try {
+      const response = await fetch('/api/plugins');
+      if (!response.ok) {
+        throw new Error('Failed to fetch plugins');
+      }
+
+      const pluginList = await response.json();
+      
+      for (const pluginMeta of pluginList) {
+        await this.loadPlugin(pluginMeta);
+      }
+
+      this.initialized = true;
+      console.log(`Plugin Manager initialized with ${this.plugins.size} plugins`);
+    } catch (error) {
+      console.error('Failed to initialize Plugin Manager:', error);
+    }
+  }
+
+  /**
+   * Load a single plugin
+   * @param {object} pluginMeta - Plugin metadata
+   */
+  async loadPlugin(pluginMeta) {
+    try {
+      // In a real implementation, you'd dynamically import the plugin
+      // For now, we'll simulate plugin loading with the echo plugin
+      if (pluginMeta.name === 'echo') {
+        const EchoPlugin = (await import('../../../community-plugins/echo/index.js')).default;
+        const pluginInstance = new EchoPlugin();
+        
+        // Initialize plugin if it has an initialize method
+        if (typeof pluginInstance.initialize === 'function') {
+          await pluginInstance.initialize();
+        }
+
+        this.plugins.set(pluginMeta.name, {
+          instance: pluginInstance,
+          metadata: pluginMeta
+        });
+
+        // Register plugin commands
+        for (const command of pluginMeta.commands) {
+          this.commands.set(command.command, pluginMeta.name);
+        }
+
+        console.log(`Loaded plugin: ${pluginMeta.name} v${pluginMeta.version}`);
+      }
+    } catch (error) {
+      console.error(`Failed to load plugin ${pluginMeta.name}:`, error);
+    }
+  }
+
+  /**
+   * Process a command message
+   * @param {string} message - The message to process
+   * @param {object} context - Chat context
+   * @returns {Promise<string|null>} Plugin response or null if not a plugin command
+   */
+  async processCommand(message, context = {}) {
+    if (!message.startsWith('/')) {
+      return null;
+    }
+
+    const parts = message.trim().split(/\s+/);
+    const command = parts[0];
+    const args = parts.slice(1);
+
+    // Check if it's a registered plugin command
+    const pluginName = this.commands.get(command);
+    if (!pluginName) {
+      return null;
+    }
+
+    const plugin = this.plugins.get(pluginName);
+    if (!plugin) {
+      return `Plugin ${pluginName} not found`;
+    }
+
+    try {
+      const response = await plugin.instance.handleCommand(command, args, context);
+      return response;
+    } catch (error) {
+      console.error(`Error executing plugin command ${command}:`, error);
+      return `Error executing command: ${error.message}`;
+    }
+  }
+
+  /**
+   * Get list of all available commands
+   * @returns {Array} List of available commands with descriptions
+   */
+  getAvailableCommands() {
+    const commands = [];
+    
+    for (const [pluginName, plugin] of this.plugins) {
+      for (const command of plugin.metadata.commands) {
+        commands.push({
+          command: command.command,
+          description: command.description,
+          plugin: pluginName
+        });
+      }
+    }
+
+    return commands;
+  }
+
+  /**
+   * Get help text for all plugins
+   * @returns {string} Formatted help text
+   */
+  getHelpText() {
+    if (this.plugins.size === 0) {
+      return 'No plugins are currently loaded.';
+    }
+
+    let helpText = '**Available Plugin Commands:**\n\n';
+    
+    for (const [pluginName, plugin] of this.plugins) {
+      helpText += `**${plugin.metadata.name} v${plugin.metadata.version}**\n`;
+      helpText += `${plugin.metadata.description}\n\n`;
+      
+      for (const command of plugin.metadata.commands) {
+        helpText += `• \`${command.command}\` - ${command.description}\n`;
+      }
+      helpText += '\n';
+    }
+
+    return helpText;
+  }
+
+  /**
+   * Check if a message is a plugin command
+   * @param {string} message - Message to check
+   * @returns {boolean} True if it's a plugin command
+   */
+  isPluginCommand(message) {
+    if (!message.startsWith('/')) return false;
+    
+    const command = message.trim().split(/\s+/)[0];
+    return this.commands.has(command);
+  }
+}
+
+// Export singleton instance
+export const pluginManager = new PluginManager();

--- a/src/routes/api/plugins/+server.js
+++ b/src/routes/api/plugins/+server.js
@@ -1,0 +1,56 @@
+import { json } from '@sveltejs/kit';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * GET /api/plugins
+ * Returns list of available community plugins
+ */
+export async function GET() {
+  try {
+    const pluginsDir = path.join(process.cwd(), 'community-plugins');
+    
+    // Check if plugins directory exists
+    if (!fs.existsSync(pluginsDir)) {
+      return json([]);
+    }
+
+    const plugins = [];
+    const pluginDirs = fs.readdirSync(pluginsDir, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name);
+
+    for (const pluginDir of pluginDirs) {
+      const pluginPath = path.join(pluginsDir, pluginDir);
+      const metadataPath = path.join(pluginPath, 'plugin.json');
+      
+      // Skip if no metadata file
+      if (!fs.existsSync(metadataPath)) {
+        continue;
+      }
+
+      try {
+        const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+        
+        // Validate required fields
+        if (!metadata.name || !metadata.version || !metadata.description) {
+          console.warn(`Invalid plugin metadata for ${pluginDir}`);
+          continue;
+        }
+
+        plugins.push({
+          ...metadata,
+          directory: pluginDir,
+          active: true // For now, all plugins are considered active
+        });
+      } catch (err) {
+        console.error(`Error reading plugin metadata for ${pluginDir}:`, err);
+      }
+    }
+
+    return json(plugins);
+  } catch (error) {
+    console.error('Error loading plugins:', error);
+    return json({ error: 'Failed to load plugins' }, { status: 500 });
+  }
+}

--- a/src/routes/api/plugins/execute/+server.js
+++ b/src/routes/api/plugins/execute/+server.js
@@ -1,0 +1,72 @@
+import { json } from '@sveltejs/kit';
+import { pluginManager } from '$lib/plugins/PluginManager.js';
+
+/**
+ * POST /api/plugins/execute
+ * Execute a plugin command
+ */
+export async function POST({ request }) {
+  try {
+    const { message, context = {} } = await request.json();
+
+    if (!message) {
+      return json({ error: 'Message is required' }, { status: 400 });
+    }
+
+    // Initialize plugin manager if not already done
+    if (!pluginManager.initialized) {
+      await pluginManager.initialize();
+    }
+
+    // Process the command
+    const response = await pluginManager.processCommand(message, context);
+
+    if (response === null) {
+      return json({ 
+        error: 'Command not recognized',
+        isPluginCommand: false 
+      }, { status: 404 });
+    }
+
+    return json({ 
+      response,
+      isPluginCommand: true 
+    });
+
+  } catch (error) {
+    console.error('Error executing plugin command:', error);
+    return json({ 
+      error: 'Internal server error',
+      details: error.message 
+    }, { status: 500 });
+  }
+}
+
+/**
+ * GET /api/plugins/execute
+ * Get available commands and help
+ */
+export async function GET() {
+  try {
+    // Initialize plugin manager if not already done
+    if (!pluginManager.initialized) {
+      await pluginManager.initialize();
+    }
+
+    const commands = pluginManager.getAvailableCommands();
+    const helpText = pluginManager.getHelpText();
+
+    return json({
+      commands,
+      helpText,
+      pluginCount: pluginManager.plugins.size
+    });
+
+  } catch (error) {
+    console.error('Error getting plugin commands:', error);
+    return json({ 
+      error: 'Internal server error',
+      details: error.message 
+    }, { status: 500 });
+  }
+}

--- a/src/routes/plugins/+page.svelte
+++ b/src/routes/plugins/+page.svelte
@@ -1,0 +1,114 @@
+<script>
+  import { onMount } from 'svelte';
+  
+  let plugins = [];
+  let loading = true;
+  let error = null;
+
+  onMount(async () => {
+    try {
+      const response = await fetch('/api/plugins');
+      if (response.ok) {
+        plugins = await response.json();
+      } else {
+        error = 'Failed to load plugins';
+      }
+    } catch (err) {
+      error = 'Error loading plugins: ' + err.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Community Plugins - QryptChat</title>
+  <meta name="description" content="Browse and manage community plugins for QryptChat" />
+</svelte:head>
+
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-4xl mx-auto">
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-6">
+      Community Plugins
+    </h1>
+    
+    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6">
+      <h2 class="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-2">
+        How to use plugins
+      </h2>
+      <p class="text-blue-800 dark:text-blue-200 mb-2">
+        Plugins extend QryptChat with additional functionality. To use a plugin:
+      </p>
+      <ol class="list-decimal list-inside text-blue-800 dark:text-blue-200 space-y-1">
+        <li>Type <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">/help</code> in any chat to see available commands</li>
+        <li>Use plugin commands like <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">/echo Hello!</code></li>
+        <li>Each plugin has its own set of commands and features</li>
+      </ol>
+    </div>
+
+    {#if loading}
+      <div class="flex justify-center items-center py-12">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <span class="ml-2 text-gray-600 dark:text-gray-400">Loading plugins...</span>
+      </div>
+    {:else if error}
+      <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+        <p class="text-red-800 dark:text-red-200">{error}</p>
+      </div>
+    {:else if plugins.length === 0}
+      <div class="text-center py-12">
+        <p class="text-gray-600 dark:text-gray-400">No plugins available yet.</p>
+      </div>
+    {:else}
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {#each plugins as plugin}
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 p-6">
+            <div class="flex items-start justify-between mb-4">
+              <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+                {plugin.name}
+              </h3>
+              <span class="text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
+                v{plugin.version}
+              </span>
+            </div>
+            
+            <p class="text-gray-600 dark:text-gray-300 mb-4">
+              {plugin.description}
+            </p>
+            
+            <div class="mb-4">
+              <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-2">
+                Available Commands:
+              </h4>
+              <div class="space-y-1">
+                {#each plugin.commands as command}
+                  <div class="flex items-center justify-between text-sm">
+                    <code class="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-blue-600 dark:text-blue-400">
+                      {command.command}
+                    </code>
+                    <span class="text-gray-500 dark:text-gray-400 text-xs ml-2">
+                      {command.description}
+                    </span>
+                  </div>
+                {/each}
+              </div>
+            </div>
+            
+            <div class="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+              <span>by {plugin.author}</span>
+              <span class="bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-200 px-2 py-1 rounded text-xs">
+                Active
+              </span>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  code {
+    font-family: 'Courier New', monospace;
+  }
+</style>


### PR DESCRIPTION
## Summary
Implements a community plugin system that allows third-party plugins to be served via PRs into the `./community-plugins` folder, addressing issue #11.

## Features Added
- **Plugin Directory Structure**: Created `community-plugins/` folder with standardized plugin format
- **Echo Plugin Example**: Simple example plugin demonstrating the system
- **Plugin Manager**: Core system for loading and executing plugins
- **API Endpoints**: `/api/plugins` and `/api/plugins/execute` for plugin management
- **Plugins Page**: UI at `/plugins` to browse available community plugins
- **Integration Guide**: Complete documentation for developers

## Plugin System Overview
- Plugins are stored in `community-plugins/{plugin-name}/` directories
- Each plugin has `plugin.json` metadata and `index.js` implementation
- Commands start with `/` (e.g., `/help`, `/echo Hello!`)
- Plugins can be easily added via PRs to the community-plugins folder

## Example Usage
```
/help          → Shows all available plugin commands
/echo Hello!   → Echo: Hello!
```

## Files Added
- `community-plugins/README.md` - Plugin system documentation
- `community-plugins/echo/` - Example echo plugin
- `src/routes/plugins/+page.svelte` - Plugin browser UI
- `src/routes/api/plugins/+server.js` - Plugin listing API
- `src/routes/api/plugins/execute/+server.js` - Command execution API
- `src/lib/plugins/PluginManager.js` - Core plugin management
- `PLUGIN_INTEGRATION_GUIDE.md` - Developer integration guide

## Next Steps
- Integrate plugin command processing into chat interface
- Add the Zymo.tv bot plugin as mentioned in the issue
- Implement plugin security and sandboxing

Closes #11