### PR TITLE
fix: typing indicator cross-browser bugs

### DIFF
--- a/src/lib/components/chat/TypingIndicator.svelte
+++ b/src/lib/components/chat/TypingIndicator.svelte
@@ -1,10 +1,15 @@
 <script>
 	let { users = [] } = $props();
 
-	const typingText = $derived(() => {
+	function displayName(user) {
+		if (typeof user === 'string') return user;
+		return user.display_name || user.username || 'Someone';
+	}
+
+	const typingText = $derived.by(() => {
 		if (users.length === 0) return '';
-		if (users.length === 1) return `${users[0].display_name || users[0].username} is typing...`;
-		if (users.length === 2) return `${users[0].display_name || users[0].username} and ${users[1].display_name || users[1].username} are typing...`;
+		if (users.length === 1) return `${displayName(users[0])} is typing...`;
+		if (users.length === 2) return `${displayName(users[0])} and ${displayName(users[1])} are typing...`;
 		return `${users.length} people are typing...`;
 	});
 </script>

--- a/src/lib/stores/chat.js
+++ b/src/lib/stores/chat.js
@@ -588,15 +588,19 @@ function createChatStore() {
 	 */
 	function handleTypingUpdate(typingData) {
 		update(state => {
-			const { userId, isTyping } = typingData;
+			const { userId, username, displayName, isTyping } = typingData;
 			let newTypingUsers = [...state.typingUsers];
 
 			if (isTyping) {
-				if (!newTypingUsers.includes(userId)) {
-					newTypingUsers.push(userId);
+				if (!newTypingUsers.some(u => u.id === userId)) {
+					newTypingUsers.push({
+						id: userId,
+						username: username || 'Someone',
+						display_name: displayName || username || null
+					});
 				}
 			} else {
-				newTypingUsers = newTypingUsers.filter(id => id !== userId);
+				newTypingUsers = newTypingUsers.filter(u => u.id !== userId);
 			}
 
 			return {

--- a/src/routes/api/typing/start/+server.js
+++ b/src/routes/api/typing/start/+server.js
@@ -21,7 +21,7 @@ export const POST = withAuth(async ({ request, locals }) => {
 		// Get internal user ID from auth user ID
 		const { data: userData, error: userError } = await supabase
 			.from('users')
-			.select('id')
+			.select('id, username, display_name')
 			.eq('auth_user_id', authUser.id)
 			.single();
 
@@ -35,6 +35,8 @@ export const POST = withAuth(async ({ request, locals }) => {
 		// Broadcast typing indicator to conversation
 		sseManager.broadcastToRoom(conversationId, MESSAGE_TYPES.USER_TYPING, {
 			userId,
+			username: userData.username,
+			displayName: userData.display_name,
 			conversationId,
 			isTyping: true
 		}, userId);


### PR DESCRIPTION
Fixes typing indicator showing code snippets on Chromium and not working on Firefox/LibreWolf. Root causes: `$derived` vs `$derived.by` misuse, and bare user IDs instead of user objects in typing store.

Closes #9