### PR TITLE
feat: add PWA app badge for unread notifications

### DIFF
--- a/src/lib/stores/chat.js
+++ b/src/lib/stores/chat.js
@@ -6,6 +6,7 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import { MESSAGE_TYPES } from '$lib/api/protocol.js';
+import { updateAppBadge } from '$lib/utils/badge.js';
 import { multiRecipientEncryption } from '$lib/crypto/multi-recipient-encryption.js';
 import { postQuantumEncryption } from '$lib/crypto/post-quantum-encryption.js';
 import { publicKeyService } from '$lib/crypto/public-key-service.js';
@@ -709,6 +710,18 @@ export const typingUsers = derived(chat, $chat => $chat.typingUsers);
 export const isConnected = derived(chat, $chat => $chat.connected);
 export const isAuthenticated = derived(chat, $chat => $chat.authenticated);
 export const currentUser = derived(chat, $chat => $chat.user);
+
+// Derived store for total unread count across all conversations
+export const totalUnreadCount = derived(chat, $chat =>
+	$chat.conversations.reduce((sum, c) => sum + (c.unread_count || 0), 0)
+);
+
+// Update PWA app badge when unread count changes
+if (browser) {
+	totalUnreadCount.subscribe(count => {
+		updateAppBadge(count);
+	});
+}
 
 // Clean up on page unload
 if (browser) {

--- a/src/lib/utils/badge.js
+++ b/src/lib/utils/badge.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview PWA App Badge utility using the Badging API
+ * Updates the OS taskbar/dock badge with unread message count
+ */
+
+import { browser } from '$app/environment';
+
+/**
+ * Check if the Badging API is supported
+ * @returns {boolean}
+ */
+export function isBadgingSupported() {
+	return browser && 'setAppBadge' in navigator;
+}
+
+/**
+ * Update the app badge with the given unread count
+ * @param {number} count - Total unread message count
+ */
+export async function updateAppBadge(count) {
+	if (!isBadgingSupported()) return;
+
+	try {
+		if (count > 0) {
+			await navigator.setAppBadge(count);
+		} else {
+			await navigator.clearAppBadge();
+		}
+	} catch (error) {
+		// Silently fail - badge API may throw in some contexts (e.g., non-installed PWA)
+		console.warn('Failed to update app badge:', error);
+	}
+}
+
+/**
+ * Clear the app badge
+ */
+export async function clearAppBadge() {
+	if (!isBadgingSupported()) return;
+
+	try {
+		await navigator.clearAppBadge();
+	} catch (error) {
+		console.warn('Failed to clear app badge:', error);
+	}
+}


### PR DESCRIPTION
Uses the Badging API (navigator.setAppBadge/clearAppBadge) to show unread count on the PWA taskbar icon. Includes feature detection for unsupported browsers.

Closes #18