### PR TITLE
fix: webhook routes - undefined params and request variables

### DIFF
--- a/src/app/api/webhooks/[id]/route.js
+++ b/src/app/api/webhooks/[id]/route.js
@@ -4,7 +4,7 @@ import { withAuth } from '@/lib/api/middleware/auth.js';
 /** Delete a webhook by ID */
 export const DELETE = withAuth(async (event) => {
 	const { supabase, user } = event.locals;
-	const { id } = params;
+	const { id } = event.context.params;
 
 	const { error } = await supabase
 		.from('webhooks')

--- a/src/app/api/webhooks/route.js
+++ b/src/app/api/webhooks/route.js
@@ -25,7 +25,7 @@ export const POST = withAuth(async (event) => {
 
 	let body;
 	try {
-		body = await request.json();
+		body = await event.request.json();
 	} catch {
 		return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
 	}


### PR DESCRIPTION
Bug 2: DELETE [id]/route.js - params was undefined
Bug 3: POST route.js - request was undefined