### PR TITLE
fix: use response.json() instead of response.NextResponse.json() in Telnyx webhook

### DIFF
--- a/src/app/api/webhooks/telnyx/sms/route.js
+++ b/src/app/api/webhooks/telnyx/sms/route.js
@@ -218,7 +218,7 @@ async function sendTelnyxResponse(fromPhone, toPhone, message) {
 		});
 
 		if (!response.ok) {
-			const errorData = await response.NextResponse.json();
+			const errorData = await response.json();
 			console.error('[TELNYX-WEBHOOK] Failed to send response SMS:', errorData);
 		} else {
 			console.log('[TELNYX-WEBHOOK] Response SMS sent successfully');


### PR DESCRIPTION
## Bug

In `src/app/api/webhooks/telnyx/sms/route.js`, the `sendTelnyxResponse` function calls `response.NextResponse.json()` on line 221 when handling Telnyx API errors. `NextResponse` is not a property of the fetch `Response` object — this throws a `TypeError` at runtime, preventing error details from being logged.

## Fix

Changed `response.NextResponse.json()` → `response.json()`.

## Impact

Without this fix, any Telnyx API error during SMS response sends causes an unhandled exception in the error logging path, masking the actual API error.