### PR TITLE
fix: use userId param and restrict sensitive fields in profile endpoint

### DIFF
--- a/src/app/api/user/profile/[userId]/route.js
+++ b/src/app/api/user/profile/[userId]/route.js
@@ -6,25 +6,42 @@ export async function GET(request, { params } = {}) {
 	try {
 		const { userId } = params;
 		const supabase = await createSupabaseServerClient();
-		
+
 		// Verify user is authenticated
 		const { data: { user: authUser }, error: authError } = await supabase.auth.getUser();
-		
+
 		if (authError || !authUser) {
 			return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
 		}
-		
-		// Get user profile
+
+		const isOwnProfile = userId === authUser.id;
+
+		if (isOwnProfile) {
+			// Own profile: return all non-sensitive fields
+			const { data: userProfile, error: profileError } = await supabase
+				.from('users')
+				.select('id, username, display_name, avatar_url, bio, website, unique_identifier, status, is_online, last_seen, last_active_at, sms_notifications_enabled, created_at, updated_at')
+				.eq('auth_user_id', authUser.id)
+				.single();
+
+			if (profileError) {
+				return NextResponse.json({ error: profileError.message }, { status: 404 });
+			}
+
+			return NextResponse.json({ user: userProfile });
+		}
+
+		// Other user's profile: return only public fields
 		const { data: userProfile, error: profileError } = await supabase
 			.from('users')
-			.select('*')
-			.eq('auth_user_id', authUser.id)
+			.select('id, username, display_name, avatar_url, bio, website, unique_identifier, status, is_online')
+			.eq('id', userId)
 			.single();
-		
+
 		if (profileError) {
 			return NextResponse.json({ error: profileError.message }, { status: 404 });
 		}
-		
+
 		return NextResponse.json({ user: userProfile });
 	} catch (error) {
 		console.error('User profile API error:', error);


### PR DESCRIPTION
## Bug

`/api/user/profile/[userId]` has two issues:

1. **Unused userId param**: The `userId` is extracted from URL params but never used in the database query. The endpoint always returns the authenticated user's own profile, regardless of the `userId` in the URL.

2. **Sensitive data exposure**: `select('*')` returns all columns including `salt`, `backup_pin_hash`, `phone_number`, and `auth_user_id` in API responses.

## Fix

- Use the `userId` param to determine whether to return own or another user's profile
- Own profile: return all non-sensitive fields (excludes `salt`, `backup_pin_hash`, `phone_number`, `auth_user_id`)
- Other user's profile: return only public fields (`id`, `username`, `display_name`, `avatar_url`, `bio`, `website`, `unique_identifier`, `status`, `is_online`)

This is consistent with the existing pattern in `/api/users/by-id/[identifier]` and `/api/users/by-username/[username]` which already return limited public fields.