### PR TITLE
fix: add authentication to SMS send-notification endpoint

### DIFF
--- a/src/app/api/sms/send-notification/route.js
+++ b/src/app/api/sms/send-notification/route.js
@@ -4,14 +4,13 @@
  */
 
 import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/api/middleware/auth.js';
 import { TwilioSMSProvider } from '@/lib/services/twilio-sms-provider.js';
 
 /**
- * Send SMS notification
- * @param {Object} params - SvelteKit request parameters
- * @param {Request} params.request - The request object
+ * Send SMS notification (requires authentication)
  */
-export async function POST(request) {
+export const POST = withAuth(async ({ request }) => {
   try {
     const { phoneNumber, message } = await request.json();
 
@@ -30,18 +29,18 @@ export async function POST(request) {
 
     // Initialize Twilio SMS provider
     const twilioProvider = new TwilioSMSProvider();
-    
+
     // Send SMS via Twilio
     const result = await twilioProvider.sendSMS(phoneNumber, message);
-    
+
     const messageId = (result && typeof result === 'object' && 'messageId' in result) ? result.messageId : 'unknown';
     const status = (result && typeof result === 'object' && 'status' in result) ? result.status : 'sent';
-    
+
     console.log('📱 [SMS-API] SMS sent successfully:', {
       messageId,
       status
     });
-    
+
     return NextResponse.json({
       success: true,
       messageId,
@@ -56,4 +55,4 @@ export async function POST(request) {
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
## Bug

`POST /api/sms/send-notification` has no authentication. Any unauthenticated HTTP request can send SMS messages via the Twilio API, potentially running up costs and enabling SMS spam/phishing from the application's phone number.

## Fix

Wrapped the handler with the existing `withAuth` middleware from `@/lib/api/middleware/auth.js`, consistent with other protected endpoints in the codebase (e.g., `/api/messages/send`, `/api/conversations/create`).

Unauthenticated requests now receive a `401 Unauthorized` response.