### PR TITLE
Fix: webhook POST handler crash — undefined request variable

### DIFF
--- a/src/app/api/webhooks/route.js
+++ b/src/app/api/webhooks/route.js
@@ -25,7 +25,7 @@ export const POST = withAuth(async (event) => {
 
 	let body;
 	try {
-		body = await request.json();
+		body = await event.request.json();
 	} catch {
 		return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
 	}


### PR DESCRIPTION
## Summary
Fixes #95

The `POST` handler in `src/app/api/webhooks/route.js` references a bare `request` variable that doesn't exist in the handler scope. The `withAuth` wrapper passes a single `event` object, so the request body must be accessed via `event.request.json()`.

## Changes
- `src/app/api/webhooks/route.js`: Changed `request.json()` → `event.request.json()` (line 28)

## Test plan
- [ ] Send `POST /api/webhooks` with valid auth and body — should return 201 instead of crashing
- [ ] Verify `GET /api/webhooks` still works (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)