### PR TITLE
Fix: webhook DELETE handler crash — undefined params variable

### DIFF
--- a/src/app/api/webhooks/[id]/route.js
+++ b/src/app/api/webhooks/[id]/route.js
@@ -4,7 +4,7 @@ import { withAuth } from '@/lib/api/middleware/auth.js';
 /** Delete a webhook by ID */
 export const DELETE = withAuth(async (event) => {
 	const { supabase, user } = event.locals;
-	const { id } = params;
+	const { id } = (await event.context?.params) || {};
 
 	const { error } = await supabase
 		.from('webhooks')


### PR DESCRIPTION
## Summary
Fixes #97

The `DELETE` handler in `src/app/api/webhooks/[id]/route.js` references a bare `params` variable that doesn't exist in the handler's scope. The `withAuth` middleware passes Next.js context as `event.context`, and in Next.js 15 `params` is a Promise.

## Changes
- `src/app/api/webhooks/[id]/route.js`: Changed `const { id } = params` → `const { id } = (await event.context?.params) || {}`

## Test plan
- [ ] Send `DELETE /api/webhooks/<id>` with valid auth — should return 200 instead of crashing
- [ ] Verify the webhook is actually deleted from the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)