### PR TITLE
Fix: escape URLs in url-link-converter HTML output

### DIFF
--- a/src/lib/utils/url-link-converter.js
+++ b/src/lib/utils/url-link-converter.js
@@ -62,9 +62,10 @@ export function convertUrlsToLinks(text) {
 		const beforeUrl = textWithPlaceholders.slice(lastIndex, match.index);
 		result += escapeHtml(beforeUrl);
 
-		// Add the URL as a clickable link
+		// Add the URL as a clickable link (escape in both href and display text)
 		const url = match[0];
-		result += `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`;
+		const escapedUrl = escapeHtml(url);
+		result += `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
 
 		lastIndex = httpsUrlRegex.lastIndex;
 	}


### PR DESCRIPTION
## Summary
Fixes #99

The `convertUrlsToLinks` function inserts matched URLs directly into HTML without escaping. URLs with `&` in query strings produce invalid HTML. This applies the existing `escapeHtml()` function to both the `href` attribute and display text.

## Changes
- `src/lib/utils/url-link-converter.js`: Pass URL through `escapeHtml()` before inserting into anchor tag

## Test plan
- [ ] Message containing `https://example.com?a=1&b=2` renders as a valid clickable link
- [ ] Message containing plain URLs still works correctly
- [ ] Code blocks with URLs inside are still unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)