### PR TITLE
Fix webhook delete route params

### DIFF
--- a/src/app/api/webhooks/[id]/route.js
+++ b/src/app/api/webhooks/[id]/route.js
@@ -4,7 +4,7 @@ import { withAuth } from '@/lib/api/middleware/auth.js';
 /** Delete a webhook by ID */
 export const DELETE = withAuth(async (event) => {
 	const { supabase, user } = event.locals;
-	const { id } = params;
+	const { id } = (await event.context?.params) || {};
 
 	const { error } = await supabase
 		.from('webhooks')

--- a/src/app/api/webhooks/[id]/route.test.js
+++ b/src/app/api/webhooks/[id]/route.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	deleteMock: vi.fn(),
+	eqMock: vi.fn()
+}));
+
+vi.mock('@/lib/api/middleware/auth.js', () => ({
+	withAuth: (handler) => (request, context) =>
+		handler({
+			request,
+			locals: {
+				supabase: {
+					from: vi.fn(() => ({
+						delete: mocks.deleteMock
+					}))
+				},
+				user: { id: 'auth-user-id' }
+			},
+			context
+		})
+}));
+
+describe('DELETE /api/webhooks/[id]', () => {
+	it('reads the webhook id from route context params', async () => {
+		mocks.eqMock.mockReturnThis();
+		mocks.deleteMock.mockReturnValue({ eq: mocks.eqMock });
+
+		const { DELETE } = await import('./route.js');
+		const response = await DELETE(new Request('https://qrypt.chat/api/webhooks/hook-1'), {
+			params: Promise.resolve({ id: 'hook-1' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ success: true });
+		expect(mocks.eqMock).toHaveBeenCalledWith('id', 'hook-1');
+		expect(mocks.eqMock).toHaveBeenCalledWith('user_id', 'auth-user-id');
+	});
+});


### PR DESCRIPTION
Summary: read the dynamic webhook id from withAuth route context instead of the undefined params variable; add a regression test that exercises DELETE /api/webhooks/[id] with async Next.js params and verifies the id/user filters. Verification: pnpm vitest run src/app/api/webhooks/[id]/route.test.js failed before the fix with ReferenceError: params is not defined; pnpm vitest run --config /tmp/vitest-qryptchat-api.config.js src/app/api/webhooks/[id]/route.test.js passes; pnpm exec oxlint src/app/api/webhooks/[id]/route.js src/app/api/webhooks/[id]/route.test.js passes. Note: the repo ESLint config currently cannot load locally because package globals is missing from the installed dependency graph, so I used oxlint for the changed files. Closes #97.