### PR TITLE
Escape generated URL links

### DIFF
--- a/src/lib/utils/url-link-converter.js
+++ b/src/lib/utils/url-link-converter.js
@@ -64,7 +64,8 @@ export function convertUrlsToLinks(text) {
 
 		// Add the URL as a clickable link
 		const url = match[0];
-		result += `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`;
+		const escapedUrl = escapeHtml(url);
+		result += `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
 
 		lastIndex = httpsUrlRegex.lastIndex;
 	}

--- a/src/lib/utils/url-link-converter.test.js
+++ b/src/lib/utils/url-link-converter.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertUrlsToLinks } from './url-link-converter.js';
+
+describe('convertUrlsToLinks', () => {
+	it('escapes ampersands inside linked URLs', () => {
+		const html = convertUrlsToLinks('See https://example.com/search?a=1&b=2');
+
+		expect(html).toContain('href="https://example.com/search?a=1&amp;b=2"');
+		expect(html).toContain('>https://example.com/search?a=1&amp;b=2</a>');
+	});
+});


### PR DESCRIPTION
Summary: escape matched URLs before placing them in generated anchor href/text; add a regression test for query strings containing ampersands so generated HTML uses &amp; instead of raw &. Verification: pnpm vitest run --config /tmp/vitest-qryptchat-api.config.js src/lib/utils/url-link-converter.test.js passes; pnpm exec oxlint src/lib/utils/url-link-converter.js src/lib/utils/url-link-converter.test.js passes. Note: the repo ESLint config currently cannot load locally because package globals is missing from the installed dependency graph, so I used oxlint for the changed files. Closes #99.