### PR TITLE
Fix Telnyx webhook response parsing bug

### DIFF
--- a/src/app/api/webhooks/telnyx/sms/route.js
+++ b/src/app/api/webhooks/telnyx/sms/route.js
@@ -218,7 +218,7 @@ async function sendTelnyxResponse(fromPhone, toPhone, message) {
 		});
 
 		if (!response.ok) {
-			const errorData = await response.NextResponse.json();
+			const errorData = await response.json();
 			console.error('[TELNYX-WEBHOOK] Failed to send response SMS:', errorData);
 		} else {
 			console.log('[TELNYX-WEBHOOK] Response SMS sent successfully');


### PR DESCRIPTION
This PR fixes a bug where  was called on a standard fetch response object, causing a crash. Changed to .