### PR TITLE
fix(profile): extract generated qryptchat IDs from URLs

### DIFF
--- a/src/lib/utils/unique-identifier.js
+++ b/src/lib/utils/unique-identifier.js
@@ -138,13 +138,13 @@ export function extractIdentifierFromUrl(url) {
         return null;
     }
     
-    // Match pattern /id/QCXXXXXXXX
-    const match = url.match(/\/id\/([A-Z0-9]{10})$/i);
+    // Match current profile IDs, with optional trailing slash, query, or hash.
+    const match = url.match(/\/id\/(qryptchat[0-9A-Z]{8})(?:[/?#]|$)/i);
     if (!match) {
         return null;
     }
     
-    const identifier = match[1].toUpperCase();
+    const identifier = parseUniqueIdentifier(match[1]);
     return validateUniqueIdentifier(identifier) ? identifier : null;
 }
 

--- a/tests/unique-identifier-utils.test.js
+++ b/tests/unique-identifier-utils.test.js
@@ -6,7 +6,9 @@ import {
     generateUniqueIdentifier, 
     validateUniqueIdentifier, 
     formatUniqueIdentifier,
-    parseUniqueIdentifier 
+    parseUniqueIdentifier,
+    generateShareableProfileUrl,
+    extractIdentifierFromUrl
 } from '../src/lib/utils/unique-identifier.js';
 
 describe('Unique Identifier Utils', () => {
@@ -128,6 +130,22 @@ describe('Unique Identifier Utils', () => {
                 const parsed = parseUniqueIdentifier(formatted);
                 expect(parsed).to.equal(id);
             });
+        });
+
+        it('should round-trip generated profile URLs back to the identifier', () => {
+            const identifier = 'qryptchatA1B2C3D4';
+            const url = generateShareableProfileUrl(identifier, 'https://qrypt.chat/');
+
+            expect(url).to.equal('https://qrypt.chat/id/qryptchatA1B2C3D4');
+            expect(extractIdentifierFromUrl(url)).to.equal(identifier);
+        });
+
+        it('should extract identifiers from profile URLs with trailing delimiters', () => {
+            const identifier = 'qryptchatA1B2C3D4';
+
+            expect(extractIdentifierFromUrl(`https://qrypt.chat/id/${identifier}/`)).to.equal(identifier);
+            expect(extractIdentifierFromUrl(`https://qrypt.chat/id/${identifier}?action=chat`)).to.equal(identifier);
+            expect(extractIdentifierFromUrl(`https://qrypt.chat/id/${identifier}#profile`)).to.equal(identifier);
         });
     });
 });


### PR DESCRIPTION
## Summary
- fixes `extractIdentifierFromUrl()` so generated `/id/qryptchat...` profile links round-trip correctly
- preserves the lowercase `qryptchat` prefix during validation by normalizing through `parseUniqueIdentifier()`
- supports trailing slash, query string, and hash delimiters on profile URLs
- adds focused coverage in `tests/unique-identifier-utils.test.js`

Fixes #105.

## Validation
- `corepack pnpm exec mocha tests/unique-identifier-utils.test.js` - 19 passing
- direct Node round-trip check for `generateShareableProfileUrl()` + `extractIdentifierFromUrl()`

## Build note
- `corepack pnpm build` compiles successfully, then fails on existing environment/config issues: ESLint cannot resolve `globals` from `eslint.config.js`, and Next page-data collection requires `supabaseUrl`.