### PR TITLE
fix(sms): handle missing Twilio credentials

### DIFF
--- a/src/lib/utils/twilio-validator.js
+++ b/src/lib/utils/twilio-validator.js
@@ -14,6 +14,13 @@
 export function validateTwilioCredentials(credentials) {
 	const errors = [];
 
+	if (!credentials || typeof credentials !== 'object' || Array.isArray(credentials)) {
+		return {
+			valid: false,
+			errors: ['Credentials object is required']
+		};
+	}
+
 	// Validate Account SID
 	if (!credentials.accountSid) {
 		errors.push('Account SID is required');

--- a/tests/twilio-validator.test.js
+++ b/tests/twilio-validator.test.js
@@ -13,6 +13,13 @@ import {
 
 describe('Twilio Validator', () => {
 	describe('validateTwilioCredentials', () => {
+		it('should return validation errors for missing credential objects', () => {
+			const result = validateTwilioCredentials(null);
+
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.errors.some(e => e.includes('Credentials object')));
+		});
+
 		it('should validate correct credentials', () => {
 			const result = validateTwilioCredentials({
 				accountSid: 'AC' + '1'.repeat(32),


### PR DESCRIPTION
## Summary
- makes `validateTwilioCredentials()` return a structured validation error for missing/non-object input instead of throwing
- adds a regression test for null credential config
- preserves existing validation behavior for valid Twilio credentials, invalid SID/token, phone format, and messaging service SID

Fixes #107.

## Validation
- `node --test tests/twilio-validator.test.js` - 16 passing
- direct Node check for `validateTwilioCredentials(null)` returning `{ valid: false, errors: [...] }`