### PR TITLE
fix: guard validateTwilioCredentials against null/non-object input

### DIFF
--- a/src/lib/utils/twilio-validator.js
+++ b/src/lib/utils/twilio-validator.js
@@ -12,6 +12,10 @@
  * @returns {{valid: boolean, errors: string[]}}
  */
 export function validateTwilioCredentials(credentials) {
+	if (!credentials || typeof credentials !== 'object') {
+		return { valid: false, errors: ['Credentials must be a non-null object'] };
+	}
+
 	const errors = [];
 
 	// Validate Account SID

--- a/tests/twilio-validator.test.js
+++ b/tests/twilio-validator.test.js
@@ -67,6 +67,24 @@ describe('Twilio Validator', () => {
 			assert.strictEqual(result.valid, true);
 			assert.strictEqual(result.errors.length, 0);
 		});
+
+		it('should return validation failure for null input', () => {
+			const result = validateTwilioCredentials(null);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.errors.length > 0);
+		});
+
+		it('should return validation failure for undefined input', () => {
+			const result = validateTwilioCredentials(undefined);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.errors.length > 0);
+		});
+
+		it('should return validation failure for non-object input', () => {
+			const result = validateTwilioCredentials('not-an-object');
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.errors.length > 0);
+		});
 	});
 
 	describe('parseTwilioError', () => {


### PR DESCRIPTION
## Summary

- `validateTwilioCredentials(null)` previously threw `TypeError: Cannot read properties of null (reading 'accountSid')` because the function accessed object properties before checking the input type
- Added early return guard at the top of the function for `null`, `undefined`, and non-object inputs
- Added test cases covering `null`, `undefined`, and string inputs

## Changes

- `src/lib/utils/twilio-validator.js`: added null/type guard at top of `validateTwilioCredentials`
- `tests/twilio-validator.test.js`: added 3 new test cases for invalid input types

Fixes #107