### PR TITLE
fix: URL extraction regex and code block placeholder collision (#105, #109)

### DIFF
--- a/src/lib/utils/unique-identifier.js
+++ b/src/lib/utils/unique-identifier.js
@@ -138,8 +138,8 @@ export function extractIdentifierFromUrl(url) {
         return null;
     }
     
-    // Match pattern /id/QCXXXXXXXX
-    const match = url.match(/\/id\/([A-Z0-9]{10})$/i);
+    // Match pattern /id/qryptchatXXXXXXXX (qryptchat prefix + 8 alphanumeric chars)
+    const match = url.match(/\/id\/(qryptchat[A-Z0-9]{8})$/i);
     if (!match) {
         return null;
     }

--- a/src/lib/utils/url-link-converter.js
+++ b/src/lib/utils/url-link-converter.js
@@ -42,7 +42,7 @@ export function convertUrlsToLinks(text) {
 
 	// Extract code blocks and replace with placeholders
 	while ((codeMatch = codeBlockRegex.exec(text)) !== null) {
-		const placeholder = `__CODE_BLOCK_${codeIndex}__`;
+		const placeholder = `<[CODE_BLOCK_${codeIndex}]>`;
 		const codeContent = codeMatch[1];
 		codeBlocks.push(`<pre><code>${escapeHtml(codeContent)}</code></pre>`);
 		textWithPlaceholders = textWithPlaceholders.replace(codeMatch[0], placeholder);
@@ -87,7 +87,7 @@ export function convertUrlsToLinks(text) {
 
 	// Restore code blocks from placeholders
 	codeBlocks.forEach((codeBlock, index) => {
-		const placeholder = `__CODE_BLOCK_${index}__`;
+		const placeholder = `<[CODE_BLOCK_${index}]>`;
 		result = result.replace(placeholder, codeBlock);
 	});
 


### PR DESCRIPTION
## Summary

Fixes two bugs reported in issues #105 and #109.

### Fix #105 - Profile ID URL extraction rejects generated qryptchat IDs

**File:** `src/lib/utils/unique-identifier.js`

The regex expected exactly 10 alphanumeric characters, but generateShareableProfileUrl() produces identifiers like qryptchatA1B2C3D4 (17 chars). Changed regex to match the actual qryptchat prefix format.

### Fix #109 - URL formatter code block placeholder collision

**File:** `src/lib/utils/url-link-converter.js`

Code blocks were replaced with __CODE_BLOCK_N__ placeholders. If a user typed that literal text, the restore step would incorrectly inject HTML. Changed delimiters to angle-bracket syntax that gets HTML-escaped in user text, making collision impossible.

## Testing

Both fixes are targeted changes that preserve existing behavior for all valid inputs while fixing the specific edge cases described in the issues.

Closes #105, Closes #109