### PR TITLE
fix: normalize chat message pagination

### DIFF
--- a/src/app/api/chat/messages/pagination.js
+++ b/src/app/api/chat/messages/pagination.js
@@ -1,0 +1,26 @@
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const DEFAULT_OFFSET = 0;
+
+export function normalizeMessagePagination(searchParams) {
+  return {
+    limit: readInteger(searchParams.get('limit'), {
+      fallback: DEFAULT_LIMIT,
+      min: 1,
+      max: MAX_LIMIT
+    }),
+    offset: readInteger(searchParams.get('offset'), {
+      fallback: DEFAULT_OFFSET,
+      min: 0
+    })
+  };
+}
+
+function readInteger(value, { fallback, min, max }) {
+  if (value == null || value === '') return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min) return fallback;
+
+  return typeof max === 'number' ? Math.min(parsed, max) : parsed;
+}

--- a/src/app/api/chat/messages/pagination.test.js
+++ b/src/app/api/chat/messages/pagination.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMessagePagination } from './pagination.js';
+
+describe('normalizeMessagePagination', () => {
+  it('uses default pagination when query params are missing', () => {
+    expect(normalizeMessagePagination(new URLSearchParams())).toEqual({
+      limit: 50,
+      offset: 0
+    });
+  });
+
+  it('accepts valid integer limit and offset params', () => {
+    expect(normalizeMessagePagination(new URLSearchParams('limit=25&offset=10'))).toEqual({
+      limit: 25,
+      offset: 10
+    });
+  });
+
+  it('falls back for malformed or negative pagination params', () => {
+    expect(normalizeMessagePagination(new URLSearchParams('limit=1abc&offset=-5'))).toEqual({
+      limit: 50,
+      offset: 0
+    });
+  });
+
+  it('caps oversized limits before building the database range', () => {
+    expect(normalizeMessagePagination(new URLSearchParams('limit=1000&offset=2'))).toEqual({
+      limit: 100,
+      offset: 2
+    });
+  });
+});

--- a/src/app/api/chat/messages/route.js
+++ b/src/app/api/chat/messages/route.js
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import { createServiceRoleClient } from '@/lib/supabase/service-role.js';
 import { createClient } from '@supabase/supabase-js';
+import { normalizeMessagePagination } from './pagination.js';
 // Lazy service role client creation
 let supabaseServiceRole = null;
 function getServiceRoleClient() {
@@ -277,8 +278,7 @@ export async function GET(request) {
     console.log('🔐 [API] ✅ Internal user ID:', userId);
 
     const conversationId = url.searchParams.get('conversation_id');
-    const limit = parseInt(url.searchParams.get('limit') || '50');
-    const offset = parseInt(url.searchParams.get('offset') || '0');
+    const { limit, offset } = normalizeMessagePagination(url.searchParams);
 
     if (!conversationId) {
       return NextResponse.json({ error: 'Missing conversation_id parameter' }, { status: 400 });


### PR DESCRIPTION
## Summary

- add shared normalization for GET /api/chat/messages pagination query params
- fall back for malformed limit/offset values instead of passing NaN or negative values into Supabase range
- cap oversized limits at 100 and cover defaults, malformed input, and caps with regression tests

Fixes #113.

## Validation

- node --input-type=module -e "...normalizeMessagePagination assertions..."
- corepack pnpm exec vitest run src/app/api/chat/messages/pagination.test.js (blocked: local Vitest config fails before tests with @vitejs/plugin-react importing vite/internal)
- corepack pnpm exec prettier --check src/app/api/chat/messages/route.js src/app/api/chat/messages/pagination.js src/app/api/chat/messages/pagination.test.js (blocked: missing prettier-plugin-svelte in local install)
- git diff --check