### PR TITLE
fix(chat): resolve async mark-read route params

### DIFF
--- a/src/app/api/chat/conversations/[id]/mark-read/route.js
+++ b/src/app/api/chat/conversations/[id]/mark-read/route.js
@@ -8,7 +8,11 @@ import { createSupabaseServerClient } from '@/lib/supabase.js';
 export async function POST(request, { params } = {}) {
 	try {
 		const supabase = await createSupabaseServerClient();
-		const conversationId = params.id;
+		const { id: conversationId } = (await params) || {};
+
+		if (!conversationId) {
+			return NextResponse.json({ error: 'Conversation ID is required' }, { status: 400 });
+		}
 		
 		// Get user from session
 		const { data: { user }, error: userError } = await supabase.auth.getUser();

--- a/src/app/api/chat/conversations/[id]/mark-read/route.test.js
+++ b/src/app/api/chat/conversations/[id]/mark-read/route.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	from: vi.fn(),
+	usersEq: vi.fn(),
+	messagesEq: vi.fn(),
+	deliveriesIn: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		auth: {
+			getUser: mocks.authGetUser
+		},
+		from: mocks.from
+	}))
+}));
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.usersEq,
+		single: vi.fn().mockResolvedValue({
+			data: { id: 'internal-user-id' },
+			error: null
+		})
+	};
+	mocks.usersEq.mockReturnValue(query);
+	return query;
+}
+
+function createMessagesQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.messagesEq
+	};
+	mocks.messagesEq.mockReturnValue(query);
+	return query;
+}
+
+function createDeliveriesQuery() {
+	const query = {
+		update: vi.fn(() => query),
+		eq: vi.fn(() => query),
+		is: vi.fn(() => query),
+		in: mocks.deliveriesIn
+	};
+	mocks.deliveriesIn.mockReturnValue({ error: null });
+	return query;
+}
+
+describe('POST /api/chat/conversations/[id]/mark-read', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+
+		mocks.from.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			if (table === 'messages') return createMessagesQuery();
+			if (table === 'deliveries') return createDeliveriesQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+	});
+
+	it('resolves async route params before filtering messages', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(new Request('https://qrypt.chat/api/chat/conversations/conversation-1/mark-read'), {
+			params: Promise.resolve({ id: 'conversation-1' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(mocks.messagesEq).toHaveBeenCalledWith('conversation_id', 'conversation-1');
+		expect(mocks.deliveriesIn).toHaveBeenCalledWith('message_id', expect.any(Object));
+	});
+
+	it('rejects requests without a conversation id', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(new Request('https://qrypt.chat/api/chat/conversations//mark-read'), {
+			params: Promise.resolve({})
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Conversation ID is required' });
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Resolve async Next.js route params before reading the conversation id in the mark-read API
- Return a 400 response when the route id is missing instead of continuing with an undefined conversation filter
- Add regression coverage for Promise-based params

## Tests
- `corepack pnpm exec vitest run --config $env:TEMP/qryptchat-vitest-no-react.config.mjs "src/app/api/chat/conversations/[id]/mark-read/route.test.js"`
- `corepack pnpm exec oxlint "src/app/api/chat/conversations/[id]/mark-read/route.js" "src/app/api/chat/conversations/[id]/mark-read/route.test.js"`

Note: the default `vitest.config.js` currently fails to load locally because `@vitejs/plugin-react` imports a non-exported Vite internal path, so the focused test was run with a minimal no-React Vitest config.