### PR TITLE
fix(api): resolve async user lookup route params

### DIFF
--- a/src/app/api/users/by-id/[identifier]/route.js
+++ b/src/app/api/users/by-id/[identifier]/route.js
@@ -16,7 +16,7 @@ export async function GET(request, { params } = {}) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const { identifier } = params;
+		const { identifier } = (await params) || {};
 
 		// Validate the identifier format
 		if (!validateUniqueIdentifier(identifier)) {

--- a/src/app/api/users/by-id/[identifier]/route.test.js
+++ b/src/app/api/users/by-id/[identifier]/route.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	rpc: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		auth: {
+			getUser: mocks.authGetUser
+		},
+		rpc: mocks.rpc
+	}))
+}));
+
+describe('GET /api/users/by-id/[identifier]', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.rpc.mockResolvedValue({
+			data: [
+				{
+					id: 'user-1',
+					username: 'alice',
+					display_name: 'Alice',
+					avatar_url: null,
+					bio: null,
+					website: null
+				}
+			],
+			error: null
+		});
+	});
+
+	it('resolves async route params before identifier validation and lookup', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-id/qryptchatA1B2C3D4'), {
+			params: Promise.resolve({ identifier: 'qryptchatA1B2C3D4' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.user.username).toBe('alice');
+		expect(mocks.rpc).toHaveBeenCalledWith('find_user_by_unique_identifier', {
+			identifier: 'qryptchatA1B2C3D4'
+		});
+	});
+
+	it('rejects missing identifiers before database lookup', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-id/'), {
+			params: Promise.resolve({})
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/api/users/by-username/[username]/route.js
+++ b/src/app/api/users/by-username/[username]/route.js
@@ -3,7 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase.js';
 
 export async function GET(request, { params } = {}) {
   try {
-    const { username } = params;
+    const { username } = (await params) || {};
     if (!username) {
       return NextResponse.json({ error: 'Username required' }, { status: 400 });
     }

--- a/src/app/api/users/by-username/[username]/route.test.js
+++ b/src/app/api/users/by-username/[username]/route.test.js
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	from: vi.fn(),
+	eq: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		from: mocks.from
+	}))
+}));
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.eq,
+		single: vi.fn().mockResolvedValue({
+			data: {
+				id: 'user-1',
+				username: 'alice',
+				display_name: 'Alice',
+				avatar_url: null,
+				bio: null,
+				unique_identifier: 'qryptchatA1B2C3D4'
+			},
+			error: null
+		})
+	};
+	mocks.eq.mockReturnValue(query);
+	return query;
+}
+
+describe('GET /api/users/by-username/[username]', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		mocks.from.mockReturnValue(createUsersQuery());
+	});
+
+	it('resolves async route params before filtering by username', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-username/Alice'), {
+			params: Promise.resolve({ username: 'Alice' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.user.username).toBe('alice');
+		expect(mocks.eq).toHaveBeenCalledWith('username', 'alice');
+	});
+
+	it('rejects missing usernames before database work', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-username/'), {
+			params: Promise.resolve({})
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Resolve Promise-based Next.js route params in user lookup endpoints before reading `username` or `identifier`
- Prevent valid `/api/users/by-username/[username]` and `/api/users/by-id/[identifier]` requests from querying with `undefined` params
- Add regression tests for async route params and missing param handling

## Tests
- `corepack pnpm exec vitest run --config $env:TEMP/qryptchat-vitest-no-react.config.mjs "src/app/api/users/by-username/[username]/route.test.js" "src/app/api/users/by-id/[identifier]/route.test.js"`
- `corepack pnpm exec oxlint "src/app/api/users/by-username/[username]/route.js" "src/app/api/users/by-username/[username]/route.test.js" "src/app/api/users/by-id/[identifier]/route.js" "src/app/api/users/by-id/[identifier]/route.test.js"`

Note: the default `vitest.config.js` still fails to load locally because `@vitejs/plugin-react` imports a non-exported Vite internal path, so the focused route tests were run with a minimal no-React Vitest config.