### PR TITLE
fix(chat): resolve message route params

### DIFF
--- a/src/app/api/chat/messages/[id]/route.js
+++ b/src/app/api/chat/messages/[id]/route.js
@@ -5,6 +5,10 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
+async function resolveRouteParams(params) {
+	return (await params) || {};
+}
+
 /**
  * Authenticate user from request cookies
  * @param {Request} request - The request object
@@ -50,7 +54,7 @@ async function authenticateUser(request) {
  */
 export async function GET(request, { params } = {}) {
 	try {
-		const messageId = params.id;
+		const { id: messageId } = await resolveRouteParams(params);
 		
 		if (!messageId) {
 			return NextResponse.json({ error: 'Message ID is required' }, { status: 400 });

--- a/src/app/api/chat/messages/[id]/route.test.js
+++ b/src/app/api/chat/messages/[id]/route.test.js
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	from: vi.fn(),
+	userEq: vi.fn(),
+	messageEq: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mocks.authGetUser
+		},
+		from: mocks.from
+	}))
+}));
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.userEq,
+		single: vi.fn().mockResolvedValue({
+			data: { id: 'internal-user-id' },
+			error: null
+		})
+	};
+	mocks.userEq.mockReturnValue(query);
+	return query;
+}
+
+function createMessagesQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.messageEq,
+		single: vi.fn().mockResolvedValue({
+			data: {
+				id: 'message-1',
+				message_recipients: [
+					{
+						encrypted_content: Buffer.from('encrypted-payload').toString('base64')
+					}
+				]
+			},
+			error: null
+		})
+	};
+	mocks.messageEq.mockReturnValue(query);
+	return query;
+}
+
+describe('GET /api/chat/messages/[id]', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+
+		mocks.from.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			if (table === 'messages') return createMessagesQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+	});
+
+	it('resolves async route params before fetching the message', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/chat/messages/message-1', {
+				headers: { cookie: 'sb-access-token=valid-token' }
+			}),
+			{ params: Promise.resolve({ id: 'message-1' }) }
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.id).toBe('message-1');
+		expect(body.encrypted_content).toBe('encrypted-payload');
+		expect(mocks.messageEq).toHaveBeenCalledWith('id', 'message-1');
+	});
+
+	it('rejects missing async route params before authentication', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/chat/messages/'), {
+			params: Promise.resolve({})
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Message ID is required' });
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- resolves Promise-based Next.js route params before reading the message id in `/api/chat/messages/[id]`
- adds regression coverage for successful async-param message lookup and missing async params

## Why
Next.js 15 can provide dynamic route params asynchronously. Reading `params.id` directly treats Promise-based params as missing, so valid message URLs can return `Message ID is required` before the handler reaches auth/database lookup.

## Validation
- `corepack pnpm exec vitest run --config %TEMP%/qryptchat-vitest-no-react.config.mjs src/app/api/chat/messages/[id]/route.test.js`
- `corepack pnpm exec oxlint src/app/api/chat/messages/[id]/route.js src/app/api/chat/messages/[id]/route.test.js`