### PR TITLE
fix(chat): add message read route

### DIFF
--- a/src/app/api/chat/messages/[id]/read/route.js
+++ b/src/app/api/chat/messages/[id]/read/route.js
@@ -1,0 +1,1 @@
+export { PATCH } from '../../route.js';

--- a/src/app/api/chat/messages/[id]/read/route.test.js
+++ b/src/app/api/chat/messages/[id]/read/route.test.js
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	serviceFrom: vi.fn(),
+	rpc: vi.fn(),
+	userEq: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mocks.authGetUser
+		}
+	}))
+}));
+
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	createServiceRoleClient: vi.fn(() => ({
+		from: mocks.serviceFrom,
+		rpc: mocks.rpc
+	}))
+}));
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.userEq,
+		single: vi.fn().mockResolvedValue({
+			data: { id: 'internal-user-id' },
+			error: null
+		})
+	};
+	mocks.userEq.mockReturnValue(query);
+	return query;
+}
+
+describe('PATCH /api/chat/messages/[id]/read', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+		mocks.rpc.mockResolvedValue({ error: null });
+	});
+
+	it('marks the async path message id as read', async () => {
+		const { PATCH } = await import('./route.js');
+		const response = await PATCH(
+			new Request('https://qrypt.chat/api/chat/messages/message-1/read', {
+				method: 'PATCH',
+				headers: { cookie: 'sb-access-token=valid-token' }
+			}),
+			{ params: Promise.resolve({ id: 'message-1' }) }
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ success: true });
+		expect(mocks.rpc).toHaveBeenCalledWith('fn_mark_message_read', {
+			p_message_id: 'message-1',
+			p_user_id: 'internal-user-id'
+		});
+	});
+
+	it('rejects missing async path params before user lookup', async () => {
+		const { PATCH } = await import('./route.js');
+		const response = await PATCH(
+			new Request('https://qrypt.chat/api/chat/messages/read', {
+				method: 'PATCH',
+				headers: { cookie: 'sb-access-token=valid-token' }
+			}),
+			{ params: Promise.resolve({}) }
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing message ID' });
+		expect(mocks.serviceFrom).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/api/chat/messages/route.js
+++ b/src/app/api/chat/messages/route.js
@@ -18,6 +18,10 @@ function getServiceRoleClient() {
 // Create regular Supabase client for authentication
 const supabaseClient = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
+async function resolveRouteParams(params) {
+  return (await params) || {};
+}
+
 /**
  * Authenticate user from request cookies
  * @param {Request} request - The request object
@@ -452,7 +456,7 @@ export async function PATCH(request, { params } = {}) {
 
     console.log('🔐 [API] ✅ User authenticated:', user.id);
 
-    const messageId = params.id;
+    const { id: messageId } = await resolveRouteParams(params);
     if (!messageId) {
       return NextResponse.json({ error: 'Missing message ID' }, { status: 400 });
     }


### PR DESCRIPTION
## Summary
- adds the missing `/api/chat/messages/[id]/read` PATCH route promised by the existing handler comment
- resolves Promise-based route params before marking a message as read
- adds regression coverage for successful async path ids and missing ids

## Why
The mark-read handler lived in `/api/chat/messages/route.js` but expected `params.id`, so the documented `/api/chat/messages/:id/read` endpoint did not actually exist and the handler could not receive a path id.

## Validation
- `corepack pnpm exec vitest run --config %TEMP%/qryptchat-vitest-no-react.config.mjs src/app/api/chat/messages/[id]/read/route.test.js`
- `corepack pnpm exec oxlint src/app/api/chat/messages/route.js src/app/api/chat/messages/[id]/read/route.js src/app/api/chat/messages/[id]/read/route.test.js`