### PR TITLE
fix(user): honor profile route id

### DIFF
--- a/src/app/api/user/profile/[userId]/route.js
+++ b/src/app/api/user/profile/[userId]/route.js
@@ -1,10 +1,17 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase.js';
 
+async function resolveRouteParams(params) {
+	return (await params) || {};
+}
 
 export async function GET(request, { params } = {}) {
 	try {
-		const { userId } = params;
+		const { userId } = await resolveRouteParams(params);
+		if (!userId) {
+			return NextResponse.json({ error: 'User ID is required' }, { status: 400 });
+		}
+
 		const supabase = await createSupabaseServerClient();
 		
 		// Verify user is authenticated
@@ -23,6 +30,10 @@ export async function GET(request, { params } = {}) {
 		
 		if (profileError) {
 			return NextResponse.json({ error: profileError.message }, { status: 404 });
+		}
+
+		if (userProfile.id !== userId && userProfile.auth_user_id !== userId) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 		}
 		
 		return NextResponse.json({ user: userProfile });

--- a/src/app/api/user/profile/[userId]/route.test.js
+++ b/src/app/api/user/profile/[userId]/route.test.js
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	from: vi.fn(),
+	eq: vi.fn(),
+	profile: {
+		id: 'internal-user-id',
+		auth_user_id: 'auth-user-id',
+		username: 'alice'
+	}
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		auth: {
+			getUser: mocks.authGetUser
+		},
+		from: mocks.from
+	}))
+}));
+
+function createProfileQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: mocks.eq,
+		single: vi.fn().mockResolvedValue({
+			data: mocks.profile,
+			error: null
+		})
+	};
+	mocks.eq.mockReturnValue(query);
+	return query;
+}
+
+describe('GET /api/user/profile/[userId]', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.from.mockImplementation((table) => {
+			if (table === 'users') return createProfileQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+	});
+
+	it('resolves async route params and returns the matching internal profile', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/user/profile/internal-user-id'), {
+			params: Promise.resolve({ userId: 'internal-user-id' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.user.id).toBe('internal-user-id');
+		expect(mocks.eq).toHaveBeenCalledWith('auth_user_id', 'auth-user-id');
+	});
+
+	it('allows the authenticated Supabase user id in the path', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/user/profile/auth-user-id'), {
+			params: Promise.resolve({ userId: 'auth-user-id' })
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it('rejects a path id for a different user', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/user/profile/other-user-id'), {
+			params: Promise.resolve({ userId: 'other-user-id' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(body).toEqual({ error: 'Forbidden' });
+	});
+});


### PR DESCRIPTION
## Summary
- resolves Promise-based params in `/api/user/profile/[userId]`
- rejects missing path ids and path ids that do not match the authenticated user's internal or auth id
- adds regression coverage for internal id, auth id, and forbidden mismatched id cases

## Why
The dynamic profile endpoint accepted `[userId]` but ignored it, so `/api/user/profile/anything` returned the authenticated user's profile. That makes the route misleading and unsafe for clients/caches that key behavior on the path id.

## Validation
- `corepack pnpm exec vitest run --config %TEMP%/qryptchat-vitest-no-react.config.mjs src/app/api/user/profile/[userId]/route.test.js`
- `corepack pnpm exec oxlint src/app/api/user/profile/[userId]/route.js src/app/api/user/profile/[userId]/route.test.js`