### PR TITLE
fix(chat): show uploaded attachments inline without a refresh

### DIFF
--- a/src/lib/components/chat/MessageAttachments.jsx
+++ b/src/lib/components/chat/MessageAttachments.jsx
@@ -35,6 +35,19 @@ export default function MessageAttachments({ messageId }) {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  // Bumped to force a re-fetch when an upload for this message completes after
+  // the component already mounted (the carrier 'file' message renders — and
+  // fetches — before its attachments finish uploading).
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!messageId) return undefined;
+    const onUpdated = (e) => {
+      if (e.detail?.messageId === messageId) setReloadKey((k) => k + 1);
+    };
+    window.addEventListener('attachments:updated', onUpdated);
+    return () => window.removeEventListener('attachments:updated', onUpdated);
+  }, [messageId]);
 
   useEffect(() => {
     if (!messageId) return undefined;
@@ -71,7 +84,7 @@ export default function MessageAttachments({ messageId }) {
       cancelled = true;
       createdUrls.forEach((u) => URL.revokeObjectURL(u));
     };
-  }, [messageId]);
+  }, [messageId, reloadKey]);
 
   if (loading) {
     return <div className="att-loading"><span className="att-spinner" /> Decrypting attachment…</div>;

--- a/src/lib/components/chat/MessageInput.jsx
+++ b/src/lib/components/chat/MessageInput.jsx
@@ -203,6 +203,13 @@ export default function MessageInput({ conversationId, disabled = false }) {
         } catch {
           // non-fatal: realtime will reconcile
         }
+
+        // The carrier 'file' message mounted (and fetched its attachments)
+        // before these uploads finished, so tell it to re-fetch now that the
+        // files exist — otherwise it stays empty until a full page refresh.
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('attachments:updated', { detail: { messageId } }));
+        }
         trackMessageSent({ conversationId, type: 'file', hasAttachments: true });
         setSelectedFiles([]);
         setMessageText('');


### PR DESCRIPTION
## Problem
After sending a file, the attachment didn't appear inline — only a full page refresh showed it.

## Root cause
`handleSend` creates the carrier `message_type: 'file'` message **first**, which mounts `<MessageAttachments>` and immediately fetches `/api/files/message/:id` — *before* the files finish uploading, so it gets an empty list. The effect was keyed only on `[messageId]`, so it never re-fetched; the attachment stayed invisible until a refresh remounted the component.

## Fix
After uploads + `loadMessages` complete, dispatch an `attachments:updated` CustomEvent with the `messageId`. `MessageAttachments` listens for its own id and bumps a `reloadKey` to re-fetch and render the now-present files. No crypto/store changes; ~15 lines.

Verified: oxlint clean. Encryption/upload/decryption were never broken (separately confirmed) — this is purely the migration-era inline-refresh regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)