### PR TITLE
fix(keys): remove stale user update on delete

### DIFF
--- a/src/app/api/keys/delete/route.js
+++ b/src/app/api/keys/delete/route.js
@@ -7,7 +7,7 @@ import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase.js';
 import { createClient } from '@supabase/supabase-js';
 
-export async function POST(request, { params } = {}) {
+export async function POST() {
 	try {
 		// Create Supabase client using the server client helper (handles auth automatically)
 		const supabase = await createSupabaseServerClient();
@@ -33,15 +33,6 @@ export async function POST(request, { params } = {}) {
 		const { error: deleteError } = await serviceSupabase
 			.from('user_public_keys')
 			.delete()
-			.eq('user_id', user.id);
-
-		// Also clear from users table if needed
-		const { error: updateError } = await serviceSupabase
-			.from('users')
-			.update({
-				ml_kem_public_key: null,
-				updated_at: new Date().toISOString()
-			})
 			.eq('user_id', user.id);
 
 		if (deleteError) {

--- a/src/app/api/keys/delete/route.test.js
+++ b/src/app/api/keys/delete/route.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	from: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		auth: {
+			getUser: mocks.authGetUser
+		}
+	}))
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		from: mocks.from
+	}))
+}));
+
+function createDeleteQuery(result) {
+	const query = {
+		delete: vi.fn(() => query),
+		eq: vi.fn().mockResolvedValue(result)
+	};
+	return query;
+}
+
+describe('POST /api/keys/delete', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+	});
+
+	it('deletes the authenticated public key without touching the users profile table', async () => {
+		const deleteQuery = createDeleteQuery({ error: null });
+		mocks.from.mockImplementation((table) => {
+			if (table === 'user_public_keys') return deleteQuery;
+			throw new Error(`Unexpected table: ${table}`);
+		});
+
+		const { POST } = await import('./route.js');
+		const response = await POST();
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ success: true, message: 'Public key deleted successfully' });
+		expect(mocks.from).toHaveBeenCalledWith('user_public_keys');
+		expect(mocks.from).not.toHaveBeenCalledWith('users');
+		expect(deleteQuery.eq).toHaveBeenCalledWith('user_id', 'auth-user-id');
+	});
+
+	it('returns a database error when public key deletion fails', async () => {
+		const deleteQuery = createDeleteQuery({ error: { message: 'delete failed' } });
+		mocks.from.mockImplementation((table) => {
+			if (table === 'user_public_keys') return deleteQuery;
+			throw new Error(`Unexpected table: ${table}`);
+		});
+
+		const { POST } = await import('./route.js');
+		const response = await POST();
+		const body = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(body).toEqual({ error: 'Database deletion failed: delete failed' });
+		expect(mocks.from).not.toHaveBeenCalledWith('users');
+	});
+});


### PR DESCRIPTION
## Summary
- remove the stale users table update from /api/keys/delete
- keep key deletion scoped to the authenticated user's user_public_keys row
- add regression coverage for successful deletion and delete failures

## Why
The current endpoint tries to clear users.ml_kem_public_key with an eq('user_id', ...) filter after deleting user_public_keys. The migrations define users.id/auth_user_id, and user_public_keys.user_id references auth.users(id), so the extra users update is stale and can make key deletion report success incorrectly.

## Validation
- corepack pnpm exec vitest run --config %TEMP%/qryptchat-vitest-no-react.config.mjs src/app/api/keys/delete/route.test.js
- corepack pnpm exec oxlint src/app/api/keys/delete/route.js src/app/api/keys/delete/route.test.js