### PR TITLE
AEO audit fixes: JSON-LD, OG/Twitter, security headers, expanded pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,19 @@
+// Security headers applied to every response. We deliberately do NOT set a
+// restrictive script-src/style-src CSP here: the app relies on inline styles,
+// Next.js inline bootstrap scripts, the crawlproof.com analytics script, and
+// Supabase image/websocket origins, so an enforcing CSP would break it. We only
+// set `frame-ancestors` (clickjacking protection) plus the other low-risk
+// hardening headers. HSTS only affects HTTPS responses (ignored over the Tor
+// http onion service, which is fine).
+const securityHeaders = [
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'geolocation=(), browsing-topics=()' },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -5,6 +21,9 @@ const nextConfig = {
   // error in an unused util) fail the production build / Railway deploy.
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }];
   },
 };
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,91 @@
+# QryptChat — Full Content
+
+> Quantum-resistant, end-to-end encrypted messaging by Profullstack, Inc.
+> Concatenated Markdown of the key public pages for LLM/RAG ingestion.
+
+## Home
+
+QryptChat is quantum-resistant, end-to-end encrypted messaging. It uses NIST-approved
+post-quantum algorithms — ML-KEM-1024 (CRYSTALS-Kyber) for key encapsulation and
+CRYSTALS-Dilithium for digital signatures — to protect messages, files, and calls against
+both current attackers and future quantum computers. It is free, open source (MIT),
+self-hostable, and accessible over Tor.
+
+How it works:
+
+1. Register with a phone number. A one-time SMS code verifies you — no email and no password.
+2. Keys are generated on your device. Your ML-KEM-1024 key pair never leaves your device, so
+   QryptChat cannot read your messages (zero-knowledge architecture).
+3. Every message is encrypted end-to-end — text, files, and voice & video calls.
+4. Stay private everywhere: use the web app or the Tor onion service, and self-host from the
+   open-source repository.
+
+Built for privacy-conscious individuals, journalists, activists, and security-minded teams.
+
+## About
+
+QryptChat is built by Profullstack, Inc. (founded 2024). Team: Anthony Ettinger
+(Founder & Developer) and mrpthedev (Developer). Mission: make communication that stays
+private for decades using cryptography already standardized by NIST, kept open source so it
+can be independently verified and self-hosted.
+
+## Security
+
+- Key encapsulation: ML-KEM-1024 (CRYSTALS-Kyber), NIST FIPS 203.
+- Digital signatures: CRYSTALS-Dilithium (ML-DSA), NIST FIPS 204.
+- Coverage: text messages, file transfers, and 1:1 and group voice & video calls are end-to-end encrypted.
+- Key custody: private keys are created and stored on-device; the server only ever sees ciphertext.
+- Why post-quantum: defends against "harvest now, decrypt later" attacks.
+- Privacy & resilience: phone-number auth (no email/password), no ads or trackers, Tor access,
+  a public warrant canary, and MIT-licensed self-hostable source.
+- Responsible disclosure: security@qrypt.chat and /.well-known/security.txt.
+
+## Pricing & Premium
+
+QryptChat is free and open source (MIT). All core messaging, calling, and encryption features
+are free, and you can self-host. An optional paid Premium tier is in development.
+
+| Feature | Free | Premium (coming soon) |
+| --- | --- | --- |
+| Post-quantum end-to-end encryption | yes | yes |
+| Encrypted voice & video calls | yes | yes |
+| Disappearing messages & file sharing | yes | yes |
+| Tor access & self-hosting | yes | yes |
+| Price | $0 forever | TBA |
+
+## FAQ
+
+Q: Is QryptChat free?
+A: Yes — free and open source (MIT). Optional Premium tier is in development.
+
+Q: What platforms does QryptChat run on?
+A: Any modern web browser, plus installable as a PWA on Android, iOS, and desktop, and reachable over Tor.
+
+Q: What makes QryptChat quantum-resistant?
+A: It encrypts with ML-KEM-1024 (CRYSTALS-Kyber) and CRYSTALS-Dilithium, protecting against
+"harvest now, decrypt later" attacks.
+
+Q: How is QryptChat different from Signal?
+A: It uses post-quantum cryptography by design, is MIT-licensed and self-hostable, and is accessible over Tor.
+
+Q: Does QryptChat require an email or password?
+A: No — sign up with a phone number and an SMS code.
+
+Q: Can I self-host QryptChat?
+A: Yes — https://github.com/profullstack/qryptchat-web
+
+Q: Can QryptChat read my messages?
+A: No — keys are generated on your device and the server only handles ciphertext.
+
+## Company
+
+- Name: Profullstack, Inc.
+- Product: QryptChat
+- Founded: 2024
+- Team: Anthony Ettinger (Founder & Developer), mrpthedev (Developer)
+- Support: support@qrypt.chat
+- Security: security@qrypt.chat
+- Business: business@qrypt.chat
+- GitHub: https://github.com/profullstack/qryptchat-web
+- License: MIT
+- Pricing: Free / open source

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,8 @@ QryptChat uses NIST-approved post-quantum algorithms (ML-KEM-1024 / CRYSTALS-Kyb
 - [Home](https://qrypt.chat/) — Product overview and feature highlights
 - [About](https://qrypt.chat/about) — Mission, team, and differentiators
 - [Security](https://qrypt.chat/security) — Encryption algorithms, zero-knowledge architecture, audit status
+- [FAQ](https://qrypt.chat/faq) — Common questions about pricing, platforms, and post-quantum encryption
+- [Pricing & Premium](https://qrypt.chat/premium) — Free vs. Premium tiers (free and open source)
 - [Encryption Test](https://qrypt.chat/encryption-test) — Live ML-KEM-1024 demo in the browser
 - [Contact](https://qrypt.chat/contact) — Support, security, and business contact emails
 - [Privacy Policy](https://qrypt.chat/privacy) — Data minimization, GDPR rights, no ads or tracking

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,9 +1,55 @@
+export const metadata = {
+  title: 'About',
+  description:
+    'QryptChat is quantum-resistant, end-to-end encrypted messaging by Profullstack, Inc. Learn about our mission, our team, and why we built a post-quantum messenger.',
+  alternates: { canonical: '/about' },
+  openGraph: { url: '/about', title: 'About QryptChat' },
+};
+
+const containerStyle = { padding: '4rem 0', maxWidth: '760px' };
+const paraStyle = { fontSize: '1.0625rem', lineHeight: 1.8, color: 'var(--color-text-secondary)', margin: '0 0 1.25rem' };
+const h2Style = { fontSize: '1.5rem', fontWeight: 700, margin: '2.5rem 0 1rem' };
+
 export default function AboutPage() {
   return (
-    <div className="container" style={{padding: '4rem 0'}}>
-      <h1 style={{fontSize: '2.5rem', fontWeight: 800, marginBottom: '1.5rem'}}>About QryptChat</h1>
-      <p style={{fontSize: '1.125rem', lineHeight: 1.8, color: 'var(--color-text-secondary)', maxWidth: '720px'}}>
-        QryptChat is a quantum-resistant, end-to-end encrypted messaging platform. Built with ML-KEM-1024 (CRYSTALS-Kyber) and CRYSTALS-Dilithium — NIST-approved post-quantum algorithms — your conversations are safe against both current and future threats including quantum computers.
+    <div className="container" style={containerStyle}>
+      <h1 style={{ fontSize: '2.5rem', fontWeight: 800, marginBottom: '1.5rem' }}>About QryptChat</h1>
+
+      <p style={paraStyle}>
+        QryptChat is a quantum-resistant, end-to-end encrypted messaging platform built by{' '}
+        <strong>Profullstack, Inc.</strong> (founded 2024). It uses ML-KEM-1024 (CRYSTALS-Kyber) and
+        CRYSTALS-Dilithium — NIST-approved post-quantum algorithms — so your conversations stay private
+        against both today&apos;s attackers and tomorrow&apos;s quantum computers.
+      </p>
+
+      <h2 style={h2Style}>Our mission</h2>
+      <p style={paraStyle}>
+        Most messengers were designed for a world without quantum computers. Encrypted traffic captured
+        today can be stored and decrypted later once large-scale quantum hardware arrives — a
+        &ldquo;harvest now, decrypt later&rdquo; attack. Our mission is to make communication that is
+        private not just today but decades from now, using cryptography that is already standardized by
+        NIST, and to keep it open source so anyone can verify and self-host it.
+      </p>
+
+      <h2 style={h2Style}>What makes QryptChat different</h2>
+      <ul style={{ ...paraStyle, paddingLeft: '1.5rem' }}>
+        <li>Post-quantum end-to-end encryption using ML-KEM-1024 and CRYSTALS-Dilithium.</li>
+        <li>Phone-number sign-up — no email address and no password required.</li>
+        <li>Encrypted voice &amp; video calls, disappearing messages, and file sharing.</li>
+        <li>Open source under the MIT license and fully self-hostable.</li>
+        <li>Accessible over Tor as a hidden service, plus a public warrant canary.</li>
+      </ul>
+
+      <h2 style={h2Style}>Team</h2>
+      <ul style={{ ...paraStyle, paddingLeft: '1.5rem' }}>
+        <li><strong>Anthony Ettinger</strong> — Founder &amp; Developer</li>
+        <li><strong>mrpthedev</strong> — Developer</li>
+      </ul>
+
+      <p style={paraStyle}>
+        QryptChat is free and open source. See the code on{' '}
+        <a href="https://github.com/profullstack/qryptchat-web" target="_blank" rel="noopener noreferrer">GitHub</a>,
+        read our <a href="/security">security overview</a>, or <a href="/contact">get in touch</a>.
       </p>
     </div>
   );

--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -41,7 +41,14 @@ export default async function BlogPostPage({ params }) {
             '@type': 'BlogPosting',
             headline: post.title,
             datePublished: post.date,
+            dateModified: post.date,
+            ...(post.excerpt ? { description: post.excerpt } : {}),
             author: { '@type': 'Organization', name: 'QryptChat' },
+            publisher: {
+              '@type': 'Organization',
+              name: 'Profullstack, Inc.',
+              logo: { '@type': 'ImageObject', url: `${siteUrl}/logo.svg` },
+            },
             mainEntityOfPage: `${siteUrl}/blog/${post.slug}`,
             ...(post.image_url ? { image: [post.image_url] } : {}),
           }),
@@ -51,7 +58,7 @@ export default async function BlogPostPage({ params }) {
       <h1 style={{ fontSize: '2.25rem', fontWeight: 700, marginTop: '0.5rem', lineHeight: 1.2 }}>{post.title}</h1>
       {post.image_url && (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={post.image_url} alt="" style={{ width: '100%', borderRadius: '0.5rem', marginTop: '1.5rem', border: '1px solid var(--color-border)' }} />
+        <img src={post.image_url} alt={post.title} style={{ width: '100%', borderRadius: '0.5rem', marginTop: '1.5rem', border: '1px solid var(--color-border)' }} />
       )}
       {post.html ? (
         <article

--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -30,7 +30,7 @@ export default async function BlogPage() {
               <Link href={`/blog/${p.slug}`} style={{ display: 'flex', gap: '1rem', padding: '1rem', textDecoration: 'none', color: 'inherit' }}>
                 {p.image_url ? (
                   // eslint-disable-next-line @next/next/no-img-element
-                  <img src={p.image_url} alt="" loading="lazy" width={80} height={80}
+                  <img src={p.image_url} alt={p.title} loading="lazy" width={80} height={80}
                     style={{ width: '5rem', height: '5rem', objectFit: 'cover', borderRadius: '0.375rem', flexShrink: 0 }} />
                 ) : (
                   <div style={{ width: '5rem', height: '5rem', borderRadius: '0.375rem', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--color-bg-secondary)', fontSize: '0.75rem', fontWeight: 700, color: 'var(--color-accent)' }}>

--- a/src/app/contact/page.jsx
+++ b/src/app/contact/page.jsx
@@ -1,9 +1,33 @@
+export const metadata = {
+  title: 'Contact',
+  description: 'How to reach QryptChat — support, security, and business contacts, plus our Discord community.',
+  alternates: { canonical: '/contact' },
+  openGraph: { url: '/contact', title: 'Contact QryptChat' },
+};
+
+const containerStyle = { padding: '4rem 0', maxWidth: '760px' };
+const paraStyle = { fontSize: '1.0625rem', lineHeight: 1.8, color: 'var(--color-text-secondary)', margin: '0 0 0.75rem' };
+
 export default function ContactPage() {
   return (
-    <div className="container" style={{padding: '4rem 0'}}>
-      <h1 style={{fontSize: '2.5rem', fontWeight: 800, marginBottom: '1.5rem'}}>Contact</h1>
-      <p>Email: <a href="mailto:hello@profullstack.com">hello@profullstack.com</a></p>
-      <p>Discord: <a href="https://discord.gg/w5nHdzpQ29">discord.gg/w5nHdzpQ29</a></p>
+    <div className="container" style={containerStyle}>
+      <h1 style={{ fontSize: '2.5rem', fontWeight: 800, marginBottom: '1.5rem' }}>Contact</h1>
+
+      <p style={paraStyle}>
+        <strong>Support:</strong> <a href="mailto:support@qrypt.chat">support@qrypt.chat</a>
+      </p>
+      <p style={paraStyle}>
+        <strong>Security &amp; responsible disclosure:</strong> <a href="mailto:security@qrypt.chat">security@qrypt.chat</a>
+      </p>
+      <p style={paraStyle}>
+        <strong>Business &amp; partnerships:</strong> <a href="mailto:business@qrypt.chat">business@qrypt.chat</a>
+      </p>
+      <p style={paraStyle}>
+        <strong>General:</strong> <a href="mailto:hello@profullstack.com">hello@profullstack.com</a>
+      </p>
+      <p style={paraStyle}>
+        <strong>Discord:</strong> <a href="https://discord.gg/w5nHdzpQ29" target="_blank" rel="noopener noreferrer">discord.gg/w5nHdzpQ29</a>
+      </p>
     </div>
   );
 }

--- a/src/app/faq/page.jsx
+++ b/src/app/faq/page.jsx
@@ -1,0 +1,68 @@
+export const metadata = {
+  title: 'FAQ',
+  description:
+    'Frequently asked questions about QryptChat: is it free, what platforms it runs on, how post-quantum encryption works, whether you can self-host, and how it compares to Signal.',
+  alternates: { canonical: '/faq' },
+  openGraph: { url: '/faq', title: 'QryptChat FAQ' },
+};
+
+const faqs = [
+  {
+    q: 'Is QryptChat free?',
+    a: 'Yes. QryptChat is free and open source under the MIT license. All core messaging, calling, and encryption features are available at no cost, and you can self-host it. An optional paid Premium tier is in development.',
+  },
+  {
+    q: 'What platforms does QryptChat run on?',
+    a: 'QryptChat runs in any modern web browser and installs as a Progressive Web App on Android, iOS, and desktop. It is also reachable as a Tor hidden service.',
+  },
+  {
+    q: 'What makes QryptChat quantum-resistant?',
+    a: 'QryptChat encrypts messages, files, and calls with NIST-approved post-quantum algorithms: ML-KEM-1024 (CRYSTALS-Kyber) for key encapsulation and CRYSTALS-Dilithium for digital signatures. These protect against "harvest now, decrypt later" attacks where traffic recorded today is decrypted once quantum computers exist.',
+  },
+  {
+    q: 'How is QryptChat different from Signal?',
+    a: 'Like Signal, QryptChat offers end-to-end encrypted messaging and calls with phone-number sign-up. The key difference is that QryptChat uses post-quantum cryptography (ML-KEM-1024 and CRYSTALS-Dilithium) by design, is MIT-licensed and self-hostable, and is accessible over Tor.',
+  },
+  {
+    q: 'Does QryptChat require an email address or password?',
+    a: 'No. You register with a phone number and a one-time SMS verification code. There is no password to leak and no email address to collect.',
+  },
+  {
+    q: 'Can I self-host QryptChat?',
+    a: 'Yes. QryptChat is open source and self-hostable. The full source code is available at github.com/profullstack/qryptchat-web.',
+  },
+  {
+    q: 'Can QryptChat read my messages?',
+    a: 'No. Encryption keys are generated on your device and never sent to our servers, so QryptChat operates on a zero-knowledge basis and only ever handles ciphertext.',
+  },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+};
+
+const containerStyle = { padding: '4rem 0', maxWidth: '760px' };
+
+export default function FaqPage() {
+  return (
+    <div className="container" style={containerStyle}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <h1 style={{ fontSize: '2.5rem', fontWeight: 800, marginBottom: '1.5rem' }}>Frequently Asked Questions</h1>
+      {faqs.map(({ q, a }) => (
+        <section key={q} style={{ margin: '0 0 1.75rem' }}>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: 700, margin: '0 0 0.5rem' }}>{q}</h2>
+          <p style={{ fontSize: '1.0625rem', lineHeight: 1.8, color: 'var(--color-text-secondary)', margin: 0 }}>{a}</p>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/home-content.jsx
+++ b/src/app/home-content.jsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Link from 'next/link';
+import { useI18n } from '@/lib/hooks/useI18n.js';
+
+export default function HomeContent() {
+  const { t } = useI18n();
+
+  return (
+    <>
+      <div className="hero">
+        <div className="container">
+          <div className="hero-content">
+            <div className="hero-text">
+              <h1 className="hero-title">{t('app.name')}</h1>
+              <p className="hero-tagline">{t('app.tagline')}</p>
+              <p className="hero-description">{t('app.description')}</p>
+              <div className="hero-actions">
+                <Link href="/auth" className="btn btn-primary">{t('nav.register')}</Link>
+                <Link href="/auth" className="btn btn-secondary">{t('nav.login')}</Link>
+              </div>
+            </div>
+            <div className="hero-visual">
+              <img src="/hero.svg" alt="Illustration of a locked, end-to-end encrypted QryptChat conversation protected by post-quantum cryptography" className="hero-image" width="500" height="500" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section className="features">
+        <div className="container">
+          <div className="section-header">
+            <h2>Why Choose QryptChat?</h2>
+            <p>Built for the future of secure communication</p>
+          </div>
+          <div className="features-grid">
+            {[
+              { num: '01', title: 'Post-Quantum Cryptography', desc: 'Uses ML-KEM-1024 (CRYSTALS-Kyber) and CRYSTALS-Dilithium algorithms approved by NIST for quantum resistance.' },
+              { num: '02', title: 'Phone Number Authentication', desc: 'Simple and secure registration using your phone number with SMS verification.' },
+              { num: '03', title: '🔐 Encrypted Voice & Video Calls', desc: 'Crystal-clear 1:1 and group calls protected with ML-KEM-1024 post-quantum encryption.' },
+              { num: '04', title: 'Real-time Messaging', desc: 'Instant message delivery with typing indicators and read receipts.' },
+              { num: '05', title: 'Multi-language Support', desc: 'Available in multiple languages with full internationalization support.' },
+            ].map(({ num, title, desc }) => (
+              <div key={num} className="feature-item">
+                <div className="feature-number">{num}</div>
+                <h3>{title}</h3>
+                <p>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="how-it-works">
+        <div className="container">
+          <div className="section-header">
+            <h2>How QryptChat Works</h2>
+            <p>Private by design — no email, no passwords, no message access.</p>
+          </div>
+          <ol className="steps">
+            <li><strong>Register with a phone number.</strong> A one-time SMS code verifies you — no email address and no password to leak.</li>
+            <li><strong>Keys are generated on your device.</strong> Your ML-KEM-1024 key pair never leaves your device, so QryptChat cannot read your messages.</li>
+            <li><strong>Every message is encrypted end-to-end.</strong> Text, files, and voice &amp; video calls are protected with NIST-approved post-quantum algorithms.</li>
+            <li><strong>Stay private, everywhere.</strong> Use QryptChat on the web or over Tor, and self-host it from the open-source (MIT) repository.</li>
+          </ol>
+          <p className="audience">
+            Built for privacy-conscious individuals, journalists, activists, and security-minded teams who need
+            communication that stays private even against future quantum computers.
+          </p>
+        </div>
+      </section>
+
+      <style>{`
+        .how-it-works { padding: var(--space-20) 0; }
+        .steps { max-width: 760px; margin: 0 auto; padding-left: var(--space-6); display: flex; flex-direction: column; gap: var(--space-4); }
+        .steps li { color: var(--color-text-secondary); line-height: 1.7; font-size: 1.0625rem; }
+        .steps li strong { color: var(--color-text-primary); }
+        .audience { max-width: 760px; margin: var(--space-8) auto 0; text-align: center; color: var(--color-text-secondary); line-height: 1.7; }
+      `}</style>
+
+      <style>{`
+        .hero {
+          background: linear-gradient(135deg, var(--color-brand-primary) 0%, var(--color-brand-secondary) 100%);
+          color: white;
+          padding: var(--space-20) 0;
+          min-height: 80vh;
+          display: flex;
+          align-items: center;
+        }
+        .hero-content {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--space-16);
+          align-items: center;
+        }
+        .hero-title {
+          font-size: 3.5rem;
+          font-weight: 800;
+          line-height: 1.1;
+          margin-bottom: var(--space-4);
+          background: linear-gradient(45deg, #ffffff, #e2e8f0);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
+        }
+        .hero-tagline { font-size: 1.5rem; font-weight: 600; margin-bottom: var(--space-4); opacity: 0.9; }
+        .hero-description { font-size: 1.125rem; line-height: 1.7; margin-bottom: var(--space-8); opacity: 0.8; }
+        .hero-actions { display: flex; gap: var(--space-4); }
+        .hero-actions .btn { padding: var(--space-4) var(--space-8); font-size: 1.125rem; font-weight: 600; }
+        .hero-actions .btn-primary { background-color: white; color: var(--color-brand-primary); border-color: white; }
+        .hero-actions .btn-primary:hover { background-color: var(--color-bg-secondary); transform: translateY(-2px); box-shadow: 0 10px 25px rgba(0,0,0,.2); }
+        .hero-actions .btn-secondary { background-color: transparent; color: white; border-color: rgba(255,255,255,.3); }
+        .hero-actions .btn-secondary:hover { background-color: rgba(255,255,255,.1); border-color: white; }
+        .hero-image { width: 100%; height: auto; max-width: 500px; opacity: 0.9; filter: drop-shadow(0 10px 30px rgba(0,0,0,.3)); }
+        .features { padding: var(--space-20) 0; background-color: var(--color-bg-secondary); }
+        .section-header { text-align: center; margin-bottom: var(--space-16); }
+        .section-header h2 { font-size: 2.5rem; font-weight: 700; color: var(--color-text-primary); margin-bottom: var(--space-4); }
+        .section-header p { font-size: 1.25rem; color: var(--color-text-secondary); }
+        .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: var(--space-8); }
+        .feature-item { background-color: var(--color-bg-primary); border: 1px solid var(--color-border-primary); border-radius: var(--radius-xl); padding: var(--space-8); transition: transform .3s ease, box-shadow .3s ease; }
+        .feature-item:hover { transform: translateY(-5px); box-shadow: var(--shadow-xl); }
+        .feature-number { display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; background: linear-gradient(135deg, var(--color-brand-primary), var(--color-brand-secondary)); color: white; border-radius: var(--radius-xl); font-weight: 700; font-size: 1.125rem; margin-bottom: var(--space-4); }
+        .feature-item h3 { font-size: 1.5rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: var(--space-3); }
+        .feature-item p { color: var(--color-text-secondary); line-height: 1.6; }
+        @media (max-width: 768px) {
+          .hero { padding: var(--space-16) 0; min-height: 70vh; }
+          .hero-content { grid-template-columns: 1fr; gap: var(--space-12); text-align: center; }
+          .hero-title { font-size: 2.5rem; }
+          .hero-actions { justify-content: center; }
+          .features-grid { grid-template-columns: 1fr; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -3,9 +3,79 @@ import ClientLayout from './client-layout.jsx';
 import FeedbackWidget from './feedback-widget.jsx';
 import Script from "next/script";
 
+const SITE_URL = (process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://qrypt.chat').replace(/\/$/, '');
+
 export const metadata = {
-  title: 'QryptChat - Quantum-Resistant Encrypted Messaging',
-  description: 'End-to-end encrypted messaging with post-quantum cryptography.',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: 'QryptChat - Quantum-Resistant Encrypted Messaging',
+    template: '%s — QryptChat',
+  },
+  description: 'End-to-end encrypted messaging with post-quantum cryptography (ML-KEM-1024 / CRYSTALS-Kyber and CRYSTALS-Dilithium). Open source, self-hostable, and accessible over Tor.',
+  applicationName: 'QryptChat',
+  keywords: [
+    'quantum-resistant messaging',
+    'post-quantum cryptography',
+    'end-to-end encryption',
+    'ML-KEM-1024',
+    'CRYSTALS-Kyber',
+    'CRYSTALS-Dilithium',
+    'encrypted messenger',
+    'private messaging',
+    'open source messenger',
+    'Signal alternative',
+  ],
+  authors: [{ name: 'Profullstack, Inc.', url: 'https://profullstack.com' }],
+  creator: 'Profullstack, Inc.',
+  publisher: 'Profullstack, Inc.',
+  openGraph: {
+    type: 'website',
+    siteName: 'QryptChat',
+    title: 'QryptChat - Quantum-Resistant Encrypted Messaging',
+    description: 'End-to-end encrypted messaging with post-quantum cryptography. Open source, self-hostable, and accessible over Tor.',
+    url: SITE_URL,
+    locale: 'en_US',
+    images: [{ url: '/banner.png', width: 1200, height: 630, alt: 'QryptChat — Quantum-Resistant Encrypted Messaging' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: '@profullstackinc',
+    creator: '@profullstackinc',
+    title: 'QryptChat - Quantum-Resistant Encrypted Messaging',
+    description: 'End-to-end encrypted messaging with post-quantum cryptography. Open source, self-hostable, and accessible over Tor.',
+    images: ['/banner.png'],
+  },
+};
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Profullstack, Inc.',
+  url: SITE_URL,
+  logo: `${SITE_URL}/logo.svg`,
+  foundingDate: '2024',
+  founder: { '@type': 'Person', name: 'Anthony Ettinger' },
+  brand: { '@type': 'Brand', name: 'QryptChat' },
+  contactPoint: [
+    { '@type': 'ContactPoint', contactType: 'customer support', email: 'support@qrypt.chat' },
+    { '@type': 'ContactPoint', contactType: 'security', email: 'security@qrypt.chat' },
+    { '@type': 'ContactPoint', contactType: 'sales', email: 'business@qrypt.chat' },
+  ],
+  sameAs: [
+    'https://github.com/profullstack',
+    'https://x.com/profullstackinc',
+    'https://bsky.app/profile/chovyfu.bsky.social',
+    'https://discord.gg/w5nHdzpQ29',
+  ],
+};
+
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'QryptChat',
+  url: SITE_URL,
+  publisher: { '@type': 'Organization', name: 'Profullstack, Inc.' },
+  inLanguage: 'en',
 };
 
 export default function RootLayout({ children }) {
@@ -17,6 +87,14 @@ export default function RootLayout({ children }) {
         <meta name="theme-color" content="#ffffff" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
       </head>
       <body suppressHydrationWarning>
         <ClientLayout>{children}</ClientLayout>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,108 +1,52 @@
-'use client';
+import HomeContent from './home-content.jsx';
 
-import Link from 'next/link';
-import { useI18n } from '@/lib/hooks/useI18n.js';
+const SITE_URL = (process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://qrypt.chat').replace(/\/$/, '');
+
+export const metadata = {
+  alternates: { canonical: '/' },
+  openGraph: { url: '/' },
+};
+
+const softwareApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'QryptChat',
+  applicationCategory: 'CommunicationApplication',
+  operatingSystem: 'Web, Android, iOS',
+  url: SITE_URL,
+  description:
+    'Quantum-resistant, end-to-end encrypted messaging using NIST-approved post-quantum algorithms (ML-KEM-1024 / CRYSTALS-Kyber and CRYSTALS-Dilithium). Open source, self-hostable, and accessible over Tor.',
+  operatingSystemVersion: 'Any modern browser',
+  license: 'https://opensource.org/licenses/MIT',
+  isAccessibleForFree: true,
+  author: { '@type': 'Organization', name: 'Profullstack, Inc.' },
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+    availability: 'https://schema.org/InStock',
+  },
+  featureList: [
+    'Post-quantum end-to-end encryption (ML-KEM-1024 / CRYSTALS-Kyber, CRYSTALS-Dilithium)',
+    'Phone-number authentication with no email required',
+    'Encrypted 1:1 and group voice & video calls',
+    'Real-time messaging with typing indicators and read receipts',
+    'Disappearing messages',
+    'Encrypted file sharing',
+    'Multi-language support',
+    'Tor onion service access',
+    'Open source (MIT), self-hostable',
+  ],
+};
 
 export default function HomePage() {
-  const { t } = useI18n();
-
   return (
     <>
-      <div className="hero">
-        <div className="container">
-          <div className="hero-content">
-            <div className="hero-text">
-              <h1 className="hero-title">{t('app.name')}</h1>
-              <p className="hero-tagline">{t('app.tagline')}</p>
-              <p className="hero-description">{t('app.description')}</p>
-              <div className="hero-actions">
-                <Link href="/auth" className="btn btn-primary">{t('nav.register')}</Link>
-                <Link href="/auth" className="btn btn-secondary">{t('nav.login')}</Link>
-              </div>
-            </div>
-            <div className="hero-visual">
-              <img src="/hero.svg" alt="QryptChat Hero" className="hero-image" />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <section className="features">
-        <div className="container">
-          <div className="section-header">
-            <h2>Why Choose QryptChat?</h2>
-            <p>Built for the future of secure communication</p>
-          </div>
-          <div className="features-grid">
-            {[
-              { num: '01', title: 'Post-Quantum Cryptography', desc: 'Uses ML-KEM-1024 (CRYSTALS-Kyber) and CRYSTALS-Dilithium algorithms approved by NIST for quantum resistance.' },
-              { num: '02', title: 'Phone Number Authentication', desc: 'Simple and secure registration using your phone number with SMS verification.' },
-              { num: '03', title: '🔐 Encrypted Voice & Video Calls', desc: 'Crystal-clear 1:1 and group calls protected with ML-KEM-1024 post-quantum encryption.' },
-              { num: '04', title: 'Real-time Messaging', desc: 'Instant message delivery with typing indicators and read receipts.' },
-              { num: '05', title: 'Multi-language Support', desc: 'Available in multiple languages with full internationalization support.' },
-            ].map(({ num, title, desc }) => (
-              <div key={num} className="feature-item">
-                <div className="feature-number">{num}</div>
-                <h3>{title}</h3>
-                <p>{desc}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <style>{`
-        .hero {
-          background: linear-gradient(135deg, var(--color-brand-primary) 0%, var(--color-brand-secondary) 100%);
-          color: white;
-          padding: var(--space-20) 0;
-          min-height: 80vh;
-          display: flex;
-          align-items: center;
-        }
-        .hero-content {
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-          gap: var(--space-16);
-          align-items: center;
-        }
-        .hero-title {
-          font-size: 3.5rem;
-          font-weight: 800;
-          line-height: 1.1;
-          margin-bottom: var(--space-4);
-          background: linear-gradient(45deg, #ffffff, #e2e8f0);
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
-          background-clip: text;
-        }
-        .hero-tagline { font-size: 1.5rem; font-weight: 600; margin-bottom: var(--space-4); opacity: 0.9; }
-        .hero-description { font-size: 1.125rem; line-height: 1.7; margin-bottom: var(--space-8); opacity: 0.8; }
-        .hero-actions { display: flex; gap: var(--space-4); }
-        .hero-actions .btn { padding: var(--space-4) var(--space-8); font-size: 1.125rem; font-weight: 600; }
-        .hero-actions .btn-primary { background-color: white; color: var(--color-brand-primary); border-color: white; }
-        .hero-actions .btn-primary:hover { background-color: var(--color-bg-secondary); transform: translateY(-2px); box-shadow: 0 10px 25px rgba(0,0,0,.2); }
-        .hero-actions .btn-secondary { background-color: transparent; color: white; border-color: rgba(255,255,255,.3); }
-        .hero-actions .btn-secondary:hover { background-color: rgba(255,255,255,.1); border-color: white; }
-        .hero-image { width: 100%; height: auto; max-width: 500px; opacity: 0.9; filter: drop-shadow(0 10px 30px rgba(0,0,0,.3)); }
-        .features { padding: var(--space-20) 0; background-color: var(--color-bg-secondary); }
-        .section-header { text-align: center; margin-bottom: var(--space-16); }
-        .section-header h2 { font-size: 2.5rem; font-weight: 700; color: var(--color-text-primary); margin-bottom: var(--space-4); }
-        .section-header p { font-size: 1.25rem; color: var(--color-text-secondary); }
-        .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: var(--space-8); }
-        .feature-item { background-color: var(--color-bg-primary); border: 1px solid var(--color-border-primary); border-radius: var(--radius-xl); padding: var(--space-8); transition: transform .3s ease, box-shadow .3s ease; }
-        .feature-item:hover { transform: translateY(-5px); box-shadow: var(--shadow-xl); }
-        .feature-number { display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; background: linear-gradient(135deg, var(--color-brand-primary), var(--color-brand-secondary)); color: white; border-radius: var(--radius-xl); font-weight: 700; font-size: 1.125rem; margin-bottom: var(--space-4); }
-        .feature-item h3 { font-size: 1.5rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: var(--space-3); }
-        .feature-item p { color: var(--color-text-secondary); line-height: 1.6; }
-        @media (max-width: 768px) {
-          .hero { padding: var(--space-16) 0; min-height: 70vh; }
-          .hero-content { grid-template-columns: 1fr; gap: var(--space-12); text-align: center; }
-          .hero-title { font-size: 2.5rem; }
-          .hero-actions { justify-content: center; }
-          .features-grid { grid-template-columns: 1fr; }
-        }
-      `}</style>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd) }}
+      />
+      <HomeContent />
     </>
   );
 }

--- a/src/app/premium/page.jsx
+++ b/src/app/premium/page.jsx
@@ -1,8 +1,49 @@
+export const metadata = {
+  title: 'Pricing & Premium',
+  description:
+    'QryptChat is free and open source. See what is included for free and what is coming to QryptChat Premium.',
+  alternates: { canonical: '/premium' },
+  openGraph: { url: '/premium', title: 'QryptChat Pricing & Premium' },
+};
+
+const containerStyle = { padding: '4rem 0', maxWidth: '760px' };
+const cellStyle = { border: '1px solid var(--color-border)', padding: '0.6rem 0.9rem', textAlign: 'left', fontSize: '0.95rem' };
+const thStyle = { ...cellStyle, background: 'var(--color-bg-secondary)', fontWeight: 600 };
+
 export default function PremiumPage() {
   return (
-    <div className="container" style={{padding: '4rem 0', textAlign: 'center'}}>
-      <h1 style={{fontSize: '2.5rem', fontWeight: 800, marginBottom: '1rem'}}>QryptChat Premium</h1>
-      <p style={{fontSize: '1.125rem', color: 'var(--color-text-secondary)'}}>Premium features coming soon.</p>
+    <div className="container" style={containerStyle}>
+      <h1 style={{ fontSize: '2.5rem', fontWeight: 800, marginBottom: '1rem' }}>Pricing &amp; Premium</h1>
+      <p style={{ fontSize: '1.125rem', lineHeight: 1.7, color: 'var(--color-text-secondary)', margin: '0 0 2rem' }}>
+        QryptChat is <strong>free and open source (MIT)</strong>. Every core messaging, calling, and
+        encryption feature is available at no cost, and you can always self-host from the{' '}
+        <a href="https://github.com/profullstack/qryptchat-web" target="_blank" rel="noopener noreferrer">source repository</a>.
+        Premium is an optional paid tier for power users — it is in development.
+      </p>
+
+      <table style={{ width: '100%', borderCollapse: 'collapse', margin: '0 0 2rem' }}>
+        <caption style={{ textAlign: 'left', color: 'var(--color-text-secondary)', fontSize: '0.85rem', marginBottom: '0.5rem' }}>
+          QryptChat plans
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col" style={thStyle}>Feature</th>
+            <th scope="col" style={thStyle}>Free</th>
+            <th scope="col" style={thStyle}>Premium (coming soon)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><th scope="row" style={cellStyle}>Post-quantum end-to-end encryption</th><td style={cellStyle}>✓</td><td style={cellStyle}>✓</td></tr>
+          <tr><th scope="row" style={cellStyle}>Encrypted voice &amp; video calls</th><td style={cellStyle}>✓</td><td style={cellStyle}>✓</td></tr>
+          <tr><th scope="row" style={cellStyle}>Disappearing messages &amp; file sharing</th><td style={cellStyle}>✓</td><td style={cellStyle}>✓</td></tr>
+          <tr><th scope="row" style={cellStyle}>Tor access &amp; self-hosting</th><td style={cellStyle}>✓</td><td style={cellStyle}>✓</td></tr>
+          <tr><th scope="row" style={cellStyle}>Price</th><td style={cellStyle}>$0 forever</td><td style={cellStyle}>TBA</td></tr>
+        </tbody>
+      </table>
+
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.95rem' }}>
+        Want early access or have a use case in mind? <a href="/contact">Contact us</a>.
+      </p>
     </div>
   );
 }

--- a/src/app/privacy/page.jsx
+++ b/src/app/privacy/page.jsx
@@ -1,3 +1,10 @@
+export const metadata = {
+  title: 'Privacy Policy',
+  description: 'QryptChat privacy policy: data minimization, GDPR rights, and no ads or third-party advertising trackers.',
+  alternates: { canonical: '/privacy' },
+  openGraph: { url: '/privacy', title: 'QryptChat Privacy Policy' },
+};
+
 export default function PrivacyPage() {
   return (
     <div className="container" style={{padding: '4rem 0', maxWidth: '720px'}}>

--- a/src/app/security/page.jsx
+++ b/src/app/security/page.jsx
@@ -1,8 +1,59 @@
+export const metadata = {
+  title: 'Security',
+  description:
+    'How QryptChat protects your messages: ML-KEM-1024 (CRYSTALS-Kyber) key encapsulation, CRYSTALS-Dilithium signatures, on-device keys, a zero-knowledge architecture, Tor access, and responsible disclosure.',
+  alternates: { canonical: '/security' },
+  openGraph: { url: '/security', title: 'QryptChat Security' },
+};
+
+const containerStyle = { padding: '4rem 0', maxWidth: '760px' };
+const paraStyle = { fontSize: '1.0625rem', lineHeight: 1.8, color: 'var(--color-text-secondary)', margin: '0 0 1.25rem' };
+const h2Style = { fontSize: '1.5rem', fontWeight: 700, margin: '2.5rem 0 1rem' };
+const listStyle = { ...paraStyle, paddingLeft: '1.5rem' };
+
 export default function SecurityPage() {
   return (
-    <div className="container" style={{padding: '4rem 0'}}>
-      <h1 style={{fontSize: '2rem', fontWeight: 800, marginBottom: '1.5rem'}}>Security</h1>
-      <p>QryptChat uses ML-KEM-1024 (CRYSTALS-Kyber) for key encapsulation and CRYSTALS-Dilithium for digital signatures — both NIST-approved post-quantum algorithms.</p>
+    <div className="container" style={containerStyle}>
+      <h1 style={{ fontSize: '2.25rem', fontWeight: 800, marginBottom: '1.5rem' }}>Security</h1>
+
+      <p style={paraStyle}>
+        QryptChat is built so that only you and the people you talk to can read your messages. Encryption
+        keys are generated on your device and never shared with our servers, giving QryptChat a
+        zero-knowledge architecture: we cannot read your messages, calls, or files even if compelled to.
+      </p>
+
+      <h2 style={h2Style}>Cryptography</h2>
+      <ul style={listStyle}>
+        <li><strong>Key encapsulation:</strong> ML-KEM-1024 (CRYSTALS-Kyber), a NIST-standardized post-quantum KEM (FIPS 203).</li>
+        <li><strong>Digital signatures:</strong> CRYSTALS-Dilithium (ML-DSA), NIST-standardized post-quantum signatures (FIPS 204).</li>
+        <li><strong>Coverage:</strong> text messages, file transfers, and 1:1 and group voice &amp; video calls are all end-to-end encrypted.</li>
+        <li><strong>Key custody:</strong> private keys are created and stored on your device; the server only ever sees ciphertext.</li>
+      </ul>
+
+      <h2 style={h2Style}>Why post-quantum</h2>
+      <p style={paraStyle}>
+        Adversaries can record encrypted traffic today and decrypt it years later once large-scale quantum
+        computers exist — the &ldquo;harvest now, decrypt later&rdquo; threat. Using NIST-approved
+        post-quantum algorithms protects your conversations against that future, not just against
+        classical attackers today.
+      </p>
+
+      <h2 style={h2Style}>Privacy &amp; resilience</h2>
+      <ul style={listStyle}>
+        <li>Phone-number authentication with no email and no password to breach.</li>
+        <li>No ads and no third-party advertising trackers.</li>
+        <li>Accessible over Tor as a hidden service for censorship resistance.</li>
+        <li>A public <a href="/warrant-canary">warrant canary</a> and a <a href="/privacy">privacy policy</a> covering data minimization and GDPR rights.</li>
+        <li>Open source under the MIT license so the cryptography can be independently audited and self-hosted.</li>
+      </ul>
+
+      <h2 style={h2Style}>Responsible disclosure</h2>
+      <p style={paraStyle}>
+        Found a vulnerability? Please report it to{' '}
+        <a href="mailto:security@qrypt.chat">security@qrypt.chat</a>. Our security contact is also published
+        at <a href="/.well-known/security.txt">/.well-known/security.txt</a>. The full source is available on{' '}
+        <a href="https://github.com/profullstack/qryptchat-web" target="_blank" rel="noopener noreferrer">GitHub</a>.
+      </p>
     </div>
   );
 }

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -3,17 +3,20 @@ import { loadAllPosts } from '@/lib/blog/posts';
 const BASE = (process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://qrypt.chat').replace(/\/$/, '');
 
 export default async function sitemap() {
+  const lastModified = new Date();
   const staticRoutes = [
-    { url: `${BASE}/`, priority: 1.0, changeFrequency: 'weekly' },
-    { url: `${BASE}/blog`, priority: 0.9, changeFrequency: 'daily' },
-    { url: `${BASE}/about`, priority: 0.8, changeFrequency: 'monthly' },
-    { url: `${BASE}/security`, priority: 0.7, changeFrequency: 'monthly' },
-    { url: `${BASE}/plugins`, priority: 0.7, changeFrequency: 'weekly' },
-    { url: `${BASE}/premium`, priority: 0.8, changeFrequency: 'monthly' },
-    { url: `${BASE}/contact`, priority: 0.6, changeFrequency: 'monthly' },
-    { url: `${BASE}/privacy`, priority: 0.5, changeFrequency: 'monthly' },
-    { url: `${BASE}/terms`, priority: 0.5, changeFrequency: 'monthly' },
-    { url: `${BASE}/warrant-canary`, priority: 0.4, changeFrequency: 'monthly' },
+    { url: `${BASE}/`, priority: 1.0, changeFrequency: 'weekly', lastModified },
+    { url: `${BASE}/blog`, priority: 0.9, changeFrequency: 'daily', lastModified },
+    { url: `${BASE}/about`, priority: 0.8, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/security`, priority: 0.7, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/faq`, priority: 0.8, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/encryption-test`, priority: 0.6, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/plugins`, priority: 0.7, changeFrequency: 'weekly', lastModified },
+    { url: `${BASE}/premium`, priority: 0.8, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/contact`, priority: 0.6, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/privacy`, priority: 0.5, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/terms`, priority: 0.5, changeFrequency: 'monthly', lastModified },
+    { url: `${BASE}/warrant-canary`, priority: 0.4, changeFrequency: 'monthly', lastModified },
   ];
 
   let postRoutes = [];

--- a/src/app/terms/page.jsx
+++ b/src/app/terms/page.jsx
@@ -1,3 +1,10 @@
+export const metadata = {
+  title: 'Terms of Service',
+  description: 'The terms that govern your use of QryptChat.',
+  alternates: { canonical: '/terms' },
+  openGraph: { url: '/terms', title: 'QryptChat Terms of Service' },
+};
+
 export default function TermsPage() {
   return (
     <div className="container" style={{padding: '4rem 0', maxWidth: '720px'}}>

--- a/src/app/warrant-canary/page.jsx
+++ b/src/app/warrant-canary/page.jsx
@@ -1,3 +1,10 @@
+export const metadata = {
+  title: 'Warrant Canary',
+  description: 'QryptChat warrant canary — our transparency statement regarding government data requests and gag orders.',
+  alternates: { canonical: '/warrant-canary' },
+  openGraph: { url: '/warrant-canary', title: 'QryptChat Warrant Canary' },
+};
+
 export default function WarrantCanaryPage() {
   return (
     <div className="container" style={{padding: '4rem 0', maxWidth: '720px'}}>

--- a/src/lib/components/Footer.jsx
+++ b/src/lib/components/Footer.jsx
@@ -50,6 +50,7 @@ export default function Footer() {
             <h4>Company</h4>
             <a href="/about">About</a>
             <a href="/blog">Blog</a>
+            <a href="/faq">FAQ</a>
             <a href="/contact">Contact</a>
             <a href="/warrant-canary">Warrant Canary</a>
           </div>


### PR DESCRIPTION
Applies the union of findings from the 13-engine AEO audit (P1→P3), grouped into 4 commits.

## Structured data / metadata
- Organization + WebSite JSON-LD site-wide; SoftwareApplication JSON-LD on homepage; enriched BlogPosting schema.
- `metadataBase`, OpenGraph + Twitter Card (`/banner.png`), keywords, title template.
- Per-page canonical + OG URL (home, about, security, premium, contact, faq, privacy, terms, warrant-canary). Homepage split into server wrapper + client component so it can carry metadata.

## Security headers (`next.config.js`)
- HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, CSP `frame-ancestors 'self'`, Referrer-Policy, Permissions-Policy.
- No restrictive script/style CSP (would break inline styles, Next bootstrap, crawlproof + Supabase); camera/mic left unrestricted for encrypted calls.

## Content
- Expanded thin `/about`, `/security`, `/premium` (free-vs-Premium pricing table).
- New `/faq` page with FAQPage JSON-LD.
- Homepage "How it works" list + audience statement.

## Crawl hygiene
- Descriptive alt text on hero + blog images; sitemap `lastModified` + added `/faq` and `/encryption-test`.
- Unified contact emails to `@qrypt.chat`; FAQ in footer; `llms.txt` updated + new `llms-full.txt`.

## Deliberately skipped
- Copyright "2026" (already dynamic `getFullYear()`), security.txt (already present), DNS SPF/DMARC/DKIM/CAA (registrar-level, not code), broken `.onion`/Bluesky links (Tor unreachable from crawlers / data value to verify).

## Notes
- Build compiles + type-checks clean. Pre-existing build error in `/api/auth/key-backup` (needs real `supabaseUrl` at build; supplied by Railway) is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)