### PR TITLE
fix: restore code blocks in URL converter

### DIFF
--- a/src/lib/utils/url-link-converter.js
+++ b/src/lib/utils/url-link-converter.js
@@ -42,7 +42,7 @@ export function convertUrlsToLinks(text) {
 
 	// Extract code blocks and replace with placeholders
 	while ((codeMatch = codeBlockRegex.exec(text)) !== null) {
-		const placeholder = `<[CODE_BLOCK_${codeIndex}]>`;
+		const placeholder = `__QRYPTCHAT_CODE_BLOCK_${codeIndex}__`;
 		const codeContent = codeMatch[1];
 		codeBlocks.push(`<pre><code>${escapeHtml(codeContent)}</code></pre>`);
 		textWithPlaceholders = textWithPlaceholders.replace(codeMatch[0], placeholder);
@@ -87,7 +87,7 @@ export function convertUrlsToLinks(text) {
 
 	// Restore code blocks from placeholders
 	codeBlocks.forEach((codeBlock, index) => {
-		const placeholder = `<[CODE_BLOCK_${index}]>`;
+		const placeholder = `__QRYPTCHAT_CODE_BLOCK_${index}__`;
 		result = result.replace(placeholder, codeBlock);
 	});
 

--- a/src/lib/utils/url-link-converter.test.js
+++ b/src/lib/utils/url-link-converter.test.js
@@ -9,4 +9,26 @@ describe('convertUrlsToLinks', () => {
 		expect(html).toContain('href="https://example.com/search?a=1&amp;b=2"');
 		expect(html).toContain('>https://example.com/search?a=1&amp;b=2</a>');
 	});
+
+	it('renders fenced code blocks instead of escaped placeholders', () => {
+		const html = convertUrlsToLinks('Before\n```const value = 1;\n```\nAfter');
+
+		expect(html).toContain('<pre><code>const value = 1;\n</code></pre>');
+		expect(html).not.toContain('CODE_BLOCK');
+		expect(html).not.toContain('&lt;[CODE_BLOCK_0]&gt;');
+	});
+
+	it('does not linkify URLs inside fenced code blocks', () => {
+		const html = convertUrlsToLinks('```https://example.com/search?a=1&b=2```');
+
+		expect(html).toContain('<pre><code>https://example.com/search?a=1&amp;b=2</code></pre>');
+		expect(html).not.toContain('<a href=');
+	});
+
+	it('escapes HTML inside fenced code blocks', () => {
+		const html = convertUrlsToLinks('```<script>alert("x")</script>```');
+
+		expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
+		expect(html).not.toContain('<script>');
+	});
 });


### PR DESCRIPTION
## Summary
- Fix fenced code block placeholders so they are restored after escaping/link conversion
- Add coverage for code blocks, URLs inside code blocks, and escaped HTML in code blocks

## Tests
- node direct converter verification: PASS
- eslint src/lib/utils/url-link-converter.js src/lib/utils/url-link-converter.test.js: PASS

Note: pnpm/vitest config currently fails before tests on this Windows environment because the repo postinstall uses Unix shell commands and Vitest config hits a Vite/plugin export mismatch.