### PR TITLE
Handle invalid Telnyx webhook JSON

### DIFF
--- a/src/app/api/webhooks/telnyx/sms/route.js
+++ b/src/app/api/webhooks/telnyx/sms/route.js
@@ -77,7 +77,13 @@ export async function POST(request) {
 			return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
 		}
 
-		const body = JSON.parse(rawBody);
+		let body;
+		try {
+			body = JSON.parse(rawBody);
+		} catch (parseError) {
+			console.error('[TELNYX-WEBHOOK] Invalid JSON payload:', parseError.message);
+			return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+		}
 		
 		// Log the incoming webhook for debugging
 		console.log('[TELNYX-WEBHOOK] Received webhook:', {

--- a/src/app/api/webhooks/telnyx/sms/route.test.js
+++ b/src/app/api/webhooks/telnyx/sms/route.test.js
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	createServiceRoleClient: vi.fn(),
+	createSMSWebhookEmailService: vi.fn()
+}));
+
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	createServiceRoleClient: mocks.createServiceRoleClient
+}));
+
+vi.mock('@/lib/services/mailgun-email-service.js', () => ({
+	createSMSWebhookEmailService: mocks.createSMSWebhookEmailService
+}));
+
+function webhookRequest(body) {
+	return new Request('https://example.com/api/webhooks/telnyx/sms', {
+		method: 'POST',
+		headers: {
+			'telnyx-signature-ed25519': 'dev-signature',
+			'telnyx-timestamp': '1720000000'
+		},
+		body
+	});
+}
+
+describe('Telnyx SMS webhook', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		delete process.env.TELNYX_PUBLIC_KEY;
+		process.env.NODE_ENV = 'development';
+	});
+
+	it('returns 400 for malformed JSON after signature verification', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(webhookRequest('{not-json'));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON payload');
+		expect(mocks.createServiceRoleClient).not.toHaveBeenCalled();
+		expect(mocks.createSMSWebhookEmailService).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- return a 400 response for malformed Telnyx SMS webhook JSON after signature verification succeeds
- add a focused regression test that ensures bad JSON does not reach Supabase or email side effects

## Validation
- `corepack pnpm exec vitest run --config %TEMP%/qryptchat-vitest-no-react.config.mjs src/app/api/webhooks/telnyx/sms/route.test.js`
- `node --check src/app/api/webhooks/telnyx/sms/route.js`
- `node --check src/app/api/webhooks/telnyx/sms/route.test.js`
- `git diff --check`

Note: the project default `vitest.config.js` currently fails to load locally because `@vitejs/plugin-react` imports an unexported `vite/internal` path. I used an equivalent temporary Vitest config without the React plugin for this API-only test.