### PR TITLE
Parse auth cookies without requiring spaces

### DIFF
--- a/src/app/api/auth/backup-pin/route.js
+++ b/src/app/api/auth/backup-pin/route.js
@@ -39,7 +39,7 @@ async function authenticateUser(request) {
 		}
 
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(cookie => {
+			cookieHeader.split(/;\s*/).map(cookie => {
 				const [name, value] = cookie.split('=');
 				return [name, decodeURIComponent(value)];
 			})

--- a/src/app/api/auth/backup-pin/route.test.js
+++ b/src/app/api/auth/backup-pin/route.test.js
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	serviceFrom: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mocks.authGetUser
+		}
+	}))
+}));
+
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	createServiceRoleClient: vi.fn(() => ({
+		from: mocks.serviceFrom
+	}))
+}));
+
+function cookieValue(token) {
+	return `base64-${Buffer.from(JSON.stringify({ access_token: token })).toString('base64')}`;
+}
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: vi.fn(() => query),
+		single: vi.fn(() =>
+			Promise.resolve({
+				data: { backup_pin_hash: 'pin-hash' },
+				error: null
+			})
+		)
+	};
+	return query;
+}
+
+describe('backup PIN cookie authentication', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+	});
+
+	it('accepts valid cookie headers without a space after semicolons', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/backup-pin', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')};session=ignored`
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ hasPin: true });
+		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+});

--- a/src/app/api/auth/salt/route.js
+++ b/src/app/api/auth/salt/route.js
@@ -28,7 +28,7 @@ async function authenticateUser(request) {
 		// Fall back to cookies
 		const cookieHeader = request.headers.get('cookie') ?? '';
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(c => {
+			cookieHeader.split(/;\s*/).map(c => {
 				const [name, ...rest] = c.split('=');
 				return [name, rest.join('=')];
 			})

--- a/src/app/api/auth/salt/route.test.js
+++ b/src/app/api/auth/salt/route.test.js
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	serviceFrom: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mocks.authGetUser
+		}
+	}))
+}));
+
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	createServiceRoleClient: vi.fn(() => ({
+		from: mocks.serviceFrom
+	}))
+}));
+
+function cookieValue(token) {
+	return `base64-${Buffer.from(JSON.stringify({ access_token: token })).toString('base64')}`;
+}
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: vi.fn(() => query),
+		single: vi.fn(() =>
+			Promise.resolve({
+				data: { salt: 'stored-salt' },
+				error: null
+			})
+		)
+	};
+	return query;
+}
+
+describe('salt cookie authentication', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			throw new Error(`Unexpected table: ${table}`);
+		});
+	});
+
+	it('accepts valid cookie headers without a space after semicolons', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/salt', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')};session=ignored`
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ salt: 'stored-salt' });
+		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+});

--- a/src/app/api/chat/conversations/[id]/participants/route.js
+++ b/src/app/api/chat/conversations/[id]/participants/route.js
@@ -36,7 +36,7 @@ async function authenticateUser(request) {
 
 		// Parse cookies to find auth token
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(cookie => {
+			cookieHeader.split(/;\s*/).map(cookie => {
 				const [name, value] = cookie.split('=');
 				return [name, decodeURIComponent(value)];
 			})

--- a/src/app/api/chat/messages/route.js
+++ b/src/app/api/chat/messages/route.js
@@ -38,7 +38,7 @@ async function authenticateUser(request) {
 
 		// Extract access token from cookies
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(cookie => {
+			cookieHeader.split(/;\s*/).map(cookie => {
 				const [name, ...rest] = cookie.split('=');
 				return [name, rest.join('=')];
 			})

--- a/src/app/api/conversations/[id]/disappearing-messages/presets/route.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/presets/route.js
@@ -23,7 +23,7 @@ async function authenticateUser(request) {
 
 		// Extract access token from cookies
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(cookie => {
+			cookieHeader.split(/;\s*/).map(cookie => {
 				const [name, ...rest] = cookie.split('=');
 				return [name, rest.join('=')];
 			})

--- a/src/app/api/conversations/[id]/disappearing-messages/route.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/route.js
@@ -36,7 +36,7 @@ async function authenticateUser(request) {
 
 		// Extract access token from cookies
 		const cookies = Object.fromEntries(
-			cookieHeader.split('; ').map(cookie => {
+			cookieHeader.split(/;\s*/).map(cookie => {
 				const [name, ...rest] = cookie.split('=');
 				return [name, rest.join('=')];
 			})

--- a/src/app/api/user/nuclear-delete/route.js
+++ b/src/app/api/user/nuclear-delete/route.js
@@ -29,7 +29,7 @@ async function authenticateUser(request) {
 
 			// Extract access token from cookies
 			const cookies = Object.fromEntries(
-				cookieHeader.split('; ').map(cookie => {
+				cookieHeader.split(/;\s*/).map(cookie => {
 					const [name, ...rest] = cookie.split('=');
 					return [name, rest.join('=')];
 				})


### PR DESCRIPTION
## Summary
- accept valid Cookie headers that omit the optional space after semicolons across protected auth/chat/conversation routes
- add regression coverage for backup PIN and salt auth cookie parsing
- leave `key-backup` to the separate open PR #140 to avoid overlapping changes

## Validation
- `pnpm exec vitest run --config vitest.api-temp.config.js src/app/api/auth/backup-pin/route.test.js src/app/api/auth/salt/route.test.js` (temporary no-plugin config used because the repo Vitest config fails to load `@vitejs/plugin-react`/Vite in this checkout)
- `node --check src/app/api/auth/backup-pin/route.js`
- `node --check src/app/api/auth/backup-pin/route.test.js`
- `node --check src/app/api/auth/salt/route.js`
- `node --check src/app/api/auth/salt/route.test.js`
- `git diff --check`

Note: `npx prettier --check ...` could not run because the repo Prettier config imports missing `prettier-plugin-svelte`.