### PR TITLE
Clear corrupted auth session storage

### DIFF
--- a/src/lib/stores/auth.js
+++ b/src/lib/stores/auth.js
@@ -77,6 +77,8 @@ export const useAuthStore = create((set, get) => ({
       }
       return { error: 'Session expired' };
     } catch {
+      localStorage.removeItem('qrypt_session');
+      localStorage.removeItem('supabase.auth.token');
       return { error: 'Failed to get session' };
     }
   },

--- a/tests/stores/auth.test.js
+++ b/tests/stores/auth.test.js
@@ -47,6 +47,19 @@ describe('Auth Store (Zustand)', () => {
     expect(result.success).toBe(false);
   });
 
+  it('clears corrupted stored session data', async () => {
+    window.localStorage.getItem.mockImplementation((key) => {
+      if (key === 'qrypt_session') return 'not-json';
+      return null;
+    });
+
+    const result = await useAuthStore.getState().getCurrentSession();
+
+    expect(result.error).toBe('Failed to get session');
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('qrypt_session');
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('supabase.auth.token');
+  });
+
   it('logs out and clears user state', async () => {
     useAuthStore.setState({ user: { id: '123', username: 'test' } });
     await useAuthStore.getState().logout();


### PR DESCRIPTION
## Summary
- Clear corrupted `qrypt_session` data when `getCurrentSession()` cannot parse/read it.
- Also remove the legacy `supabase.auth.token` entry so future auth checks do not keep retrying stale state.
- Add auth store coverage for corrupted stored session data.

## Tests
- `vitest run tests/stores/auth.test.js --config <minimal auth-store config>` (7 passed)