### PR TITLE
Normalize avatar bearer token parsing

### DIFF
--- a/src/app/api/auth/upload-avatar/route.js
+++ b/src/app/api/auth/upload-avatar/route.js
@@ -3,13 +3,23 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseAuth = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
+function getBearerToken(authHeader) {
+	if (typeof authHeader !== 'string') return null;
+
+	const match = authHeader.match(/^Bearer\s+(.+)$/i);
+	const token = match?.[1]?.trim();
+
+	return token || null;
+}
+
 async function authenticateBearerToken(request) {
 	const authHeader = request.headers.get('authorization');
-	if (!authHeader || !authHeader.startsWith('Bearer ')) {
+	const token = getBearerToken(authHeader);
+
+	if (!token) {
 		return { error: 'Authentication required' };
 	}
 
-	const token = authHeader.substring(7);
 	const { data: { user }, error } = await supabaseAuth.auth.getUser(token);
 
 	if (error || !user?.id) {

--- a/src/app/api/auth/upload-avatar/route.test.js
+++ b/src/app/api/auth/upload-avatar/route.test.js
@@ -24,6 +24,15 @@ function avatarRequest(method) {
 	});
 }
 
+function avatarRequestWithAuthorization(method, authorization) {
+	return new Request('https://example.com/api/auth/upload-avatar', {
+		method,
+		headers: {
+			authorization
+		}
+	});
+}
+
 describe('upload-avatar authentication', () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -59,6 +68,32 @@ describe('upload-avatar authentication', () => {
 		expect(response.status).toBe(401);
 		expect(body.error).toBe('Invalid authentication token');
 		expect(mocks.authGetUser).toHaveBeenCalledWith(forgedToken);
+		expect(mocks.createClient).toHaveBeenCalledTimes(1);
+		expect(mocks.createClient).toHaveBeenCalledWith('https://example.supabase.co', 'anon-key');
+	});
+
+	it('normalizes bearer scheme casing and extra spaces before validating the token', async () => {
+		const { DELETE } = await import('./route.js');
+
+		const response = await DELETE(avatarRequestWithAuthorization('DELETE', `bearer   ${forgedToken}  `));
+		const body = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(body.error).toBe('Invalid authentication token');
+		expect(mocks.authGetUser).toHaveBeenCalledWith(forgedToken);
+		expect(mocks.createClient).toHaveBeenCalledTimes(1);
+		expect(mocks.createClient).toHaveBeenCalledWith('https://example.supabase.co', 'anon-key');
+	});
+
+	it('does not validate an empty bearer header', async () => {
+		const { DELETE } = await import('./route.js');
+
+		const response = await DELETE(avatarRequestWithAuthorization('DELETE', 'Bearer   '));
+		const body = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(body.error).toBe('Authentication required');
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
 		expect(mocks.createClient).toHaveBeenCalledTimes(1);
 		expect(mocks.createClient).toHaveBeenCalledWith('https://example.supabase.co', 'anon-key');
 	});


### PR DESCRIPTION
## Summary
- normalize the upload-avatar bearer token parser so case-insensitive schemes and extra spaces still validate the supplied token
- keep empty bearer headers from calling Supabase token validation
- add focused regression coverage for POST/DELETE auth behavior

## Validation
- `vitest run src/app/api/auth/upload-avatar/route.test.js`