### PR TITLE
Validate invite token payload shape

### DIFF
--- a/src/lib/invites/verify.js
+++ b/src/lib/invites/verify.js
@@ -46,6 +46,14 @@ function b64urlDecode(value) {
 }
 
 /**
+ * @param {number} value
+ * @returns {boolean}
+ */
+function isUnixSecond(value) {
+	return Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
  * Wrap a raw 32-byte Ed25519 public key (base64) into a Node KeyObject by
  * prepending the SPKI DER header and importing as DER/SPKI.
  * @param {string} base64 base64-encoded raw 32-byte public key
@@ -114,8 +122,23 @@ export async function verifyInviteToken(token, getIssuerPublicKey) {
 	if (typeof payload.jti !== 'string' || !payload.jti) {
 		throw new InviteVerificationError('bad_format', 'invite payload missing jti');
 	}
-	if (typeof payload.exp !== 'number') {
+	if (!/^[0-9a-f]{32}$/u.test(payload.jti)) {
+		throw new InviteVerificationError('bad_format', 'invite payload has invalid jti');
+	}
+	if (typeof payload.tier !== 'string' || !payload.tier) {
+		throw new InviteVerificationError('bad_format', 'invite payload missing tier');
+	}
+	if (!isUnixSecond(payload.iat)) {
+		throw new InviteVerificationError('bad_format', 'invite payload missing iat');
+	}
+	if (!isUnixSecond(payload.exp)) {
 		throw new InviteVerificationError('bad_format', 'invite payload missing exp');
+	}
+	if (payload.exp <= payload.iat) {
+		throw new InviteVerificationError('bad_format', 'invite payload expiry must be after iat');
+	}
+	if (!Number.isSafeInteger(payload.uses) || payload.uses !== 1) {
+		throw new InviteVerificationError('bad_format', 'invite payload uses must be 1');
 	}
 
 	const issuerPublicKey = await getIssuerPublicKey(payload.iss);

--- a/src/lib/invites/verify.test.js
+++ b/src/lib/invites/verify.test.js
@@ -91,10 +91,29 @@ describe('verifyInviteToken', () => {
 	});
 
 	it('rejects an expired token', async () => {
-		const token = mintToken(privateKey, basePayload({ exp: nowSec() - 60 }));
+		const token = mintToken(privateKey, basePayload({ iat: nowSec() - 3600, exp: nowSec() - 60 }));
 		await expect(verifyInviteToken(token, getIssuerPublicKey)).rejects.toMatchObject({
 			code: 'expired',
 		});
+	});
+
+	it('rejects signed tokens with invalid payload shape', async () => {
+		const cases = [
+			{ jti: 'not-hex' },
+			{ tier: '' },
+			{ iat: undefined },
+			{ iat: nowSec() + 10, exp: nowSec() },
+			{ exp: `${nowSec() + 3600}` },
+			{ uses: 0 },
+			{ uses: 2 },
+		];
+
+		for (const overrides of cases) {
+			const token = mintToken(privateKey, basePayload(overrides));
+			await expect(verifyInviteToken(token, getIssuerPublicKey)).rejects.toMatchObject({
+				code: 'bad_format',
+			});
+		}
 	});
 
 	it('rejects a token signed by the wrong issuer key', async () => {


### PR DESCRIPTION
## Summary
- validate invite `jti`, `tier`, `iat`, `exp`, and single-use `uses` fields before accepting signed invite tokens
- reject malformed signed payloads before issuer lookup/redeem flow
- update the expired-token test so it stays well-formed while expired

## Tests
- `vitest run src/lib/invites/verify.test.js src/lib/invites/mint.test.js`
- `node --check src/lib/invites/verify.js`
- `git diff --check`