### PR TITLE
Normalize salt bearer tokens

### DIFF
--- a/src/app/api/auth/salt/route.js
+++ b/src/app/api/auth/salt/route.js
@@ -12,6 +12,15 @@ const supabaseClient = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
+function getBearerToken(authHeader) {
+	if (typeof authHeader !== 'string') return null;
+
+	const match = authHeader.match(/^Bearer\s+(.+)$/i);
+	const token = match?.[1]?.trim();
+
+	return token || null;
+}
+
 /**
  * Authenticate caller and return their auth user.
  * Accepts either a Bearer token (Authorization header) or Supabase cookies.
@@ -19,8 +28,8 @@ const supabaseClient = createClient(
 async function authenticateUser(request) {
 	try {
 		const authHeader = request.headers.get('authorization');
-		if (authHeader?.startsWith('Bearer ')) {
-			const token = authHeader.substring(7);
+		const token = getBearerToken(authHeader);
+		if (token) {
 			const { data: { user }, error } = await supabaseClient.auth.getUser(token);
 			if (!error && user) return { user };
 		}

--- a/src/app/api/auth/salt/route.test.js
+++ b/src/app/api/auth/salt/route.test.js
@@ -69,4 +69,35 @@ describe('salt cookie authentication', () => {
 		expect(body).toEqual({ salt: 'stored-salt' });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
 	});
+
+	it('normalizes bearer scheme casing and extra spaces', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/salt', {
+				headers: {
+					authorization: 'bearer   access-token  '
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ salt: 'stored-salt' });
+		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+
+	it('ignores an empty bearer header and falls back to cookies', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/salt', {
+				headers: {
+					authorization: 'Bearer   ',
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('cookie-token')}`
+				}
+			})
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.authGetUser).toHaveBeenCalledWith('cookie-token');
+	});
 });


### PR DESCRIPTION
## Summary
- normalize auth/salt Bearer headers with case-insensitive scheme handling and whitespace trimming
- ignore empty Bearer headers so cookie auth can still be used
- add focused salt auth tests for flexible Bearer parsing and empty-header fallback

## Tests
- `vitest run src/app/api/auth/salt/route.test.js`
- `node --check src/app/api/auth/salt/route.js`
- `node --check src/app/api/auth/salt/route.test.js`
- `git diff --check`