### PR TITLE
Normalize WebSocket bearer tokens

### DIFF
--- a/src/lib/websocket/middleware/auth.js
+++ b/src/lib/websocket/middleware/auth.js
@@ -5,6 +5,15 @@
 
 import { createClient } from '@supabase/supabase-js';
 
+function getBearerToken(authHeader) {
+	if (typeof authHeader !== 'string') return null;
+
+	const match = authHeader.match(/^Bearer\s+(.+)$/i);
+	const token = match?.[1]?.trim();
+
+	return token || null;
+}
+
 /**
  * Extract JWT token from WebSocket request
  * @param {Object} request - WebSocket upgrade request
@@ -13,8 +22,9 @@ import { createClient } from '@supabase/supabase-js';
 function extractToken(request) {
 	// Try to get token from Authorization header
 	const authHeader = request.headers.authorization;
-	if (authHeader && authHeader.startsWith('Bearer ')) {
-		return authHeader.substring(7);
+	const bearerToken = getBearerToken(authHeader);
+	if (bearerToken) {
+		return bearerToken;
 	}
 
 	// Try to get token from query parameters

--- a/src/lib/websocket/middleware/auth.test.js
+++ b/src/lib/websocket/middleware/auth.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn()
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getUser: mocks.authGetUser
+		}
+	}))
+}));
+
+function websocketRequest({ authorization, url = '/socket' }) {
+	return {
+		url,
+		headers: {
+			host: 'qrypt.chat',
+			...(authorization ? { authorization } : {})
+		}
+	};
+}
+
+describe('authenticateWebSocket bearer token parsing', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+		process.env.PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+	});
+
+	it('normalizes bearer scheme casing and extra spaces', async () => {
+		const { authenticateWebSocket } = await import('./auth.js');
+		const result = await authenticateWebSocket(
+			websocketRequest({ authorization: 'bearer   access-token  ' })
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.user).toMatchObject({
+			id: 'auth-user-id',
+			access_token: 'access-token'
+		});
+		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+
+	it('ignores an empty bearer header and falls back to query tokens', async () => {
+		const { authenticateWebSocket } = await import('./auth.js');
+		const result = await authenticateWebSocket(
+			websocketRequest({
+				authorization: 'Bearer   ',
+				url: '/socket?token=query-token'
+			})
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.user).toMatchObject({
+			id: 'auth-user-id',
+			access_token: 'query-token'
+		});
+		expect(mocks.authGetUser).toHaveBeenCalledWith('query-token');
+	});
+});


### PR DESCRIPTION
## Summary
- normalize WebSocket Authorization bearer parsing with case-insensitive scheme and flexible spacing
- trim extracted bearer tokens before Supabase auth lookup
- add focused regression tests for spaced/case-insensitive bearer headers and empty bearer query fallback

## Tests
- .\node_modules\.bin\vitest.CMD run src\lib\websocket\middleware\auth.test.js
- node --check src\lib\websocket\middleware\auth.js
- node --check src\lib\websocket\middleware\auth.test.js
- git diff --check