### PR TITLE
fix(users): exclude current user from search

### DIFF
--- a/src/app/api/users/search/route.js
+++ b/src/app/api/users/search/route.js
@@ -36,7 +36,7 @@ export async function GET(request, { params } = {}) {
 			.from('users')
 			.select('id, username, display_name, avatar_url, phone_number, unique_identifier')
 			.or(`username.ilike.%${sanitizedQuery}%,display_name.ilike.%${sanitizedQuery}%,phone_number.ilike.%${sanitizedQuery}%,unique_identifier.ilike.%${sanitizedQuery}%`)
-			.neq('id', user.id) // Exclude current user
+			.neq('auth_user_id', user.id) // Exclude current user by the auth UUID
 			.limit(50); // Get more results for better sorting
 	
 		if (error) {

--- a/src/app/api/users/search/route.test.js
+++ b/src/app/api/users/search/route.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getUser: vi.fn(),
+	from: vi.fn(),
+	select: vi.fn(),
+	or: vi.fn(),
+	neq: vi.fn(),
+	limit: vi.fn(),
+	createSupabaseServerClient: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: mocks.createSupabaseServerClient
+}));
+
+describe('user search', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		mocks.getUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-1' } },
+			error: null
+		});
+		mocks.from.mockReturnValue({ select: mocks.select });
+		mocks.select.mockReturnValue({ or: mocks.or });
+		mocks.or.mockReturnValue({ neq: mocks.neq });
+		mocks.neq.mockReturnValue({ limit: mocks.limit });
+		mocks.limit.mockResolvedValue({ data: [], error: null });
+		mocks.createSupabaseServerClient.mockResolvedValue({
+			auth: { getUser: mocks.getUser },
+			from: mocks.from
+		});
+	});
+
+	it('excludes the authenticated user with the auth_user_id column', async () => {
+		const { GET } = await import('./route.js');
+
+		const response = await GET(new Request('https://example.com/api/users/search?q=alice'));
+
+		expect(response.status).toBe(200);
+		expect(mocks.neq).toHaveBeenCalledWith('auth_user_id', 'auth-user-1');
+	});
+});


### PR DESCRIPTION
## Summary

- exclude the authenticated user from search with the `auth_user_id` column instead of the internal profile `id`
- add a focused regression test for the Supabase query filter

Fixes #158

## Validation

- focused Vitest route test: 1 passed (minimal Node config used because the repository's default `@vitejs/plugin-react` / Vite dependency mismatch aborts before test collection)
- `npx oxlint src/app/api/users/search/route.js src/app/api/users/search/route.test.js` (passes with the existing unused `params` warning)
- `git diff --check`
