### PR TITLE
fix(messages): avoid code block placeholder collisions

### DIFF
--- a/src/lib/utils/url-link-converter.js
+++ b/src/lib/utils/url-link-converter.js
@@ -36,13 +36,17 @@ export function convertUrlsToLinks(text) {
 	// First, handle code blocks (```...```) to protect them from other processing
 	const codeBlockRegex = /```([\s\S]*?)```/g;
 	const codeBlocks = [];
+	let placeholderPrefix = '__QRYPTCHAT_CODE_BLOCK_';
+	while (text.includes(placeholderPrefix)) {
+		placeholderPrefix = `_${placeholderPrefix}`;
+	}
 	let textWithPlaceholders = text;
 	let codeMatch;
 	let codeIndex = 0;
 
 	// Extract code blocks and replace with placeholders
 	while ((codeMatch = codeBlockRegex.exec(text)) !== null) {
-		const placeholder = `__QRYPTCHAT_CODE_BLOCK_${codeIndex}__`;
+		const placeholder = `${placeholderPrefix}${codeIndex}__`;
 		const codeContent = codeMatch[1];
 		codeBlocks.push(`<pre><code>${escapeHtml(codeContent)}</code></pre>`);
 		textWithPlaceholders = textWithPlaceholders.replace(codeMatch[0], placeholder);
@@ -87,7 +91,7 @@ export function convertUrlsToLinks(text) {
 
 	// Restore code blocks from placeholders
 	codeBlocks.forEach((codeBlock, index) => {
-		const placeholder = `__QRYPTCHAT_CODE_BLOCK_${index}__`;
+		const placeholder = `${placeholderPrefix}${index}__`;
 		result = result.replace(placeholder, codeBlock);
 	});
 

--- a/src/lib/utils/url-link-converter.test.js
+++ b/src/lib/utils/url-link-converter.test.js
@@ -31,4 +31,14 @@ describe('convertUrlsToLinks', () => {
 		expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
 		expect(html).not.toContain('<script>');
 	});
+
+	it('preserves text that resembles an internal code block placeholder', () => {
+		const html = convertUrlsToLinks(
+			'Literal __QRYPTCHAT_CODE_BLOCK_0__ then ```const value = 1;```'
+		);
+
+		expect(html).toBe(
+			'Literal __QRYPTCHAT_CODE_BLOCK_0__ then <pre><code>const value = 1;</code></pre>'
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- generate code-block placeholders with a prefix that cannot collide with the original message
- preserve literal text such as `__QRYPTCHAT_CODE_BLOCK_0__`
- add regression coverage for the collision case

## Bug
The formatter used predictable placeholder text while processing fenced code blocks. If a user message contained the same literal marker, the rendered code block replaced that text instead and left the real block as a placeholder.

## Tests
- focused URL converter suite: 5/5 passed with a minimal Vitest config
- direct regression assertion: passed
- changed-file oxlint: passed
- `git diff --check`: passed

The repository's normal Vitest config is currently blocked before test execution by the pre-existing `@vitejs/plugin-react` / `vite/internal` package export mismatch. No invoice will be sent unless this PR is merged and accepted.