### PR TITLE
fix(messages): reject non-decimal pagination values

### DIFF
--- a/src/app/api/chat/messages/pagination.js
+++ b/src/app/api/chat/messages/pagination.js
@@ -18,6 +18,7 @@ export function normalizeMessagePagination(searchParams) {
 
 function readInteger(value, { fallback, min, max }) {
   if (value == null || value === '') return fallback;
+  if (!/^\d+$/.test(value)) return fallback;
 
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < min) return fallback;

--- a/src/app/api/chat/messages/pagination.test.js
+++ b/src/app/api/chat/messages/pagination.test.js
@@ -23,6 +23,13 @@ describe('normalizeMessagePagination', () => {
     });
   });
 
+  it('rejects non-decimal integer pagination spellings', () => {
+    expect(normalizeMessagePagination(new URLSearchParams('limit=1e2&offset=0x10'))).toEqual({
+      limit: 50,
+      offset: 0
+    });
+  });
+
   it('caps oversized limits before building the database range', () => {
     expect(normalizeMessagePagination(new URLSearchParams('limit=1000&offset=2'))).toEqual({
       limit: 100,


### PR DESCRIPTION
## Summary
- make chat message pagination accept only plain decimal integer query values
- reject surprising numeric spellings such as `limit=1e2` and `offset=0x10` instead of letting `Number()` coerce them into database ranges
- keep existing defaults, lower bounds, and max-limit capping behavior

## Verification
- Direct Node check of `normalizeMessagePagination` for default, valid, malformed, non-decimal, and oversized limit cases

## Note
`pnpm vitest run src/app/api/chat/messages/pagination.test.js` could not start in this Windows environment because project dependency setup runs a Unix-only postinstall (`command`, `true`) and the local Vitest config then fails while loading `@vitejs/plugin-react`/`vite`. The focused normalization behavior was verified directly with Node.