### PR TITLE
fix(webhooks): block private IPv4-mapped hosts

### DIFF
--- a/src/lib/webhooks/url-validation.js
+++ b/src/lib/webhooks/url-validation.js
@@ -82,14 +82,35 @@ function isPrivateIpv4([a, b]) {
 
 function isPrivateIpv6(host) {
 	const normalized = host.toLowerCase();
+	const mappedIpv4 = parseIpv4MappedIpv6(normalized);
+	if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
+
 	return (
 		normalized === '::' ||
 		normalized === '::1' ||
 		normalized.startsWith('fe80:') ||
 		normalized.startsWith('fc') ||
-		normalized.startsWith('fd') ||
-		normalized.startsWith('::ffff:127.') ||
-		normalized.startsWith('::ffff:10.') ||
-		normalized.startsWith('::ffff:192.168.')
+		normalized.startsWith('fd')
 	);
+}
+
+function parseIpv4MappedIpv6(host) {
+	if (!host.startsWith('::ffff:')) return null;
+
+	const mapped = host.slice('::ffff:'.length);
+	const dotted = parseIpv4(mapped);
+	if (dotted) return dotted;
+
+	const parts = mapped.split(':');
+	if (parts.length !== 2) return null;
+
+	const words = parts.map((part) => {
+		if (!/^[0-9a-f]{1,4}$/i.test(part)) return Number.NaN;
+		return Number.parseInt(part, 16);
+	});
+
+	if (!words.every(Number.isInteger)) return null;
+
+	const [high, low] = words;
+	return [high >> 8, high & 255, low >> 8, low & 255];
 }

--- a/tests/webhook-url-validation.test.js
+++ b/tests/webhook-url-validation.test.js
@@ -29,9 +29,18 @@ describe('validateWebhookUrl', () => {
 			'http://192.168.1.1/hook',
 			'http://[::1]/hook',
 			'http://[fe80::1]/hook',
-			'http://[fd00::1]/hook'
+			'http://[fd00::1]/hook',
+			'http://[::ffff:169.254.169.254]/hook',
+			'http://[::ffff:172.16.0.1]/hook'
 		]) {
 			expect(validateWebhookUrl(url)).toMatchObject({ ok: false });
 		}
+	});
+
+	it('allows public IPv4-mapped IPv6 webhook destinations', () => {
+		expect(validateWebhookUrl('https://[::ffff:93.184.216.34]/hook')).toEqual({
+			ok: true,
+			url: 'https://[::ffff:5db8:d822]/hook'
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Block private IPv4 ranges when they are supplied as IPv4-mapped IPv6 webhook hosts
- Parse both dotted and Node-normalized hexadecimal mapped forms, e.g. `::ffff:a9fe:a9fe`
- Add regression coverage for link-local and RFC1918 mapped hosts while keeping public mapped addresses allowed

## Why
The webhook destination validator blocked private IPv4 literals and common IPv6 local ranges, but Node normalizes inputs like `http://[::ffff:169.254.169.254]/hook` to `::ffff:a9fe:a9fe`. That bypassed the existing mapped-host string checks and could allow SSRF-style webhook destinations to private infrastructure.

## Validation
- Direct Node behavior check imported `validateWebhookUrl` and verified mapped `169.254`, `172.16`, `10`, and `192.168` hosts are blocked while a public mapped address is allowed.
- `git diff --check`

Note: `pnpm exec vitest run tests/webhook-url-validation.test.js` attempted a Windows postinstall and failed on the repo's POSIX `command -v ... || true` hook. Running the local Vitest shim then hit a Vite/plugin-react export mismatch under Node 24 before test collection, so I validated the pure URL helper directly with Node and left the Vitest regression in the PR for CI.