### PR TITLE
fix(auth): trim anonymous registration usernames

### DIFF
--- a/src/app/api/auth/register-anon/route.js
+++ b/src/app/api/auth/register-anon/route.js
@@ -62,11 +62,13 @@ export async function POST(request) {
 		}
 
 		const { inviteToken, username, displayName, publicKey } = body || {};
+		const cleanUsername = typeof username === 'string' ? username.trim() : '';
+		const cleanDisplayName = typeof displayName === 'string' ? displayName.trim() : '';
 
 		if (!inviteToken || typeof inviteToken !== 'string') {
 			return NextResponse.json({ error: 'Invite token is required' }, { status: 400 });
 		}
-		if (!username || typeof username !== 'string') {
+		if (!cleanUsername) {
 			return NextResponse.json({ error: 'Username is required' }, { status: 400 });
 		}
 		if (!publicKey || typeof publicKey !== 'string') {
@@ -116,7 +118,7 @@ export async function POST(request) {
 		const { data: usernameCheck } = await serviceSupabase
 			.from('users')
 			.select('id')
-			.ilike('username', username)
+			.ilike('username', cleanUsername)
 			.single();
 		if (usernameCheck) {
 			return NextResponse.json(
@@ -152,8 +154,8 @@ export async function POST(request) {
 				auth_user_id: authUser.id,
 				phone_number: null,
 				account_type: 'anonymous',
-				username,
-				display_name: displayName || username,
+				username: cleanUsername,
+				display_name: cleanDisplayName || cleanUsername,
 				created_at: new Date().toISOString(),
 				updated_at: new Date().toISOString()
 			})

--- a/src/app/api/auth/register-anon/route.test.js
+++ b/src/app/api/auth/register-anon/route.test.js
@@ -24,15 +24,15 @@ vi.mock('@/lib/invites/verify.js', () => ({
 	InviteVerificationError: class InviteVerificationError extends Error {}
 }));
 
-function registerRequest(authorization) {
+function registerRequest(authorization, body = {
+	inviteToken: 'qci1.payload.signature',
+	username: 'anon-user',
+	publicKey: 'ml-kem-public-key'
+}) {
 	return new Request('https://example.com/api/auth/register-anon', {
 		method: 'POST',
 		headers: authorization ? { authorization } : {},
-		body: JSON.stringify({
-			inviteToken: 'qci1.payload.signature',
-			username: 'anon-user',
-			publicKey: 'ml-kem-public-key'
-		})
+		body: JSON.stringify(body)
 	});
 }
 
@@ -68,6 +68,22 @@ describe('register-anon bearer authentication', () => {
 		expect(body.error).toBe('Missing authorization header');
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.serverAuthGetUser).not.toHaveBeenCalled();
+		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();
+	});
+
+	it('rejects whitespace-only usernames before validating the session', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(registerRequest('Bearer access-token-123', {
+			inviteToken: 'qci1.payload.signature',
+			username: '   ',
+			publicKey: 'ml-kem-public-key'
+		}));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Username is required');
+		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- Trim anonymous registration usernames before duplicate checks and insert
- Trim display names and fall back to the cleaned username when blank
- Reject whitespace-only usernames before touching auth/session validation

## Why
Anonymous invite registration accepted raw username strings. A value like `  alice  ` could be stored with leading/trailing spaces, and a whitespace-only username could get past the basic truthiness check. That makes account display and duplicate detection less reliable.

## Validation
- `node --check src/app/api/auth/register-anon/route.js`
- `node --check src/app/api/auth/register-anon/route.test.js`
- `git diff --check`

Note: `node_modules/.bin/vitest.cmd run src/app/api/auth/register-anon/route.test.js` still fails before test collection because this repo's Vitest config loads @vitejs/plugin-react against a Vite build that does not export `./internal` under the current Windows/Node runtime. The focused regression test is included for CI once the project runner resolves normally.