### PR TITLE
fix(webhooks): reject blank webhook delete ids

### DIFF
--- a/src/app/api/webhooks/[id]/route.js
+++ b/src/app/api/webhooks/[id]/route.js
@@ -5,11 +5,16 @@ import { withAuth } from '@/lib/api/middleware/auth.js';
 export const DELETE = withAuth(async (event) => {
 	const { supabase, user } = event.locals;
 	const { id } = (await event.context?.params) || {};
+	const webhookId = typeof id === 'string' ? id.trim() : '';
+
+	if (!webhookId) {
+		return NextResponse.json({ error: 'Webhook id is required' }, { status: 400 });
+	}
 
 	const { error } = await supabase
 		.from('webhooks')
 		.delete()
-		.eq('id', id)
+		.eq('id', webhookId)
 		.eq('user_id', user.id);
 
 	if (error) {

--- a/src/app/api/webhooks/[id]/route.test.js
+++ b/src/app/api/webhooks/[id]/route.test.js
@@ -22,6 +22,19 @@ vi.mock('@/lib/api/middleware/auth.js', () => ({
 }));
 
 describe('DELETE /api/webhooks/[id]', () => {
+	it('rejects blank webhook ids before deleting', async () => {
+		const { DELETE } = await import('./route.js');
+		const response = await DELETE(new Request('https://qrypt.chat/api/webhooks/%20'), {
+			params: Promise.resolve({ id: '   ' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Webhook id is required' });
+		expect(mocks.deleteMock).not.toHaveBeenCalled();
+		expect(mocks.eqMock).not.toHaveBeenCalled();
+	});
+
 	it('reads the webhook id from route context params', async () => {
 		mocks.eqMock.mockReturnThis();
 		mocks.deleteMock.mockReturnValue({ eq: mocks.eqMock });


### PR DESCRIPTION
## Summary
- Reject blank webhook ids in the DELETE route before building the Supabase delete query.
- Trim the route param before matching the webhook id so whitespace-only ids cannot reach `.eq('id', ...)`.
- Add a focused regression test that asserts blank ids return 400 and do not call delete.

## Validation
- `node --check src/app/api/webhooks/[id]/route.js`
- `node --check src/app/api/webhooks/[id]/route.test.js`
- `git diff --check`

I also attempted the focused Vitest file, but this checkout fails before test collection because `@vitejs/plugin-react` imports Vite `./internal`, which is not exported by the installed Vite package in this Windows/Node environment. The regression test is included in the PR for maintainers' normal CI/runtime.