### PR TITLE
fix(files): reject blank file route ids

### DIFF
--- a/src/app/api/files/[fileId]/route.js
+++ b/src/app/api/files/[fileId]/route.js
@@ -7,6 +7,14 @@ async function resolveRouteParams(params) {
 	return (await params) || {};
 }
 
+function normalizeFileId(fileId) {
+	return typeof fileId === 'string' ? fileId.trim() : '';
+}
+
+function missingFileIdResponse() {
+	return NextResponse.json({ error: 'File ID is required' }, { status: 400 });
+}
+
 export async function GET(request, { params } = {}) {
 	try {
 		// Create Supabase server client
@@ -19,6 +27,10 @@ export async function GET(request, { params } = {}) {
 		}
 
 		const { fileId } = await resolveRouteParams(params);
+		const normalizedFileId = normalizeFileId(fileId);
+		if (!normalizedFileId) {
+			return missingFileIdResponse();
+		}
 		console.log(`📁 [FILE-DOWNLOAD] Download request from auth user: ${user.id} for file: ${fileId}`);
 
 		// Get the internal user ID from the users table using auth_user_id
@@ -57,7 +69,7 @@ export async function GET(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('id', fileId)
+			.eq('id', normalizedFileId)
 			.eq('messages.conversations.conversation_participants.user_id', userId)
 			.single();
 
@@ -163,6 +175,10 @@ export async function HEAD(request, { params } = {}) {
 
 		const userId = user.id;
 		const { fileId } = await resolveRouteParams(params);
+		const normalizedFileId = normalizeFileId(fileId);
+		if (!normalizedFileId) {
+			return missingFileIdResponse();
+		}
 
 		// Get file metadata from database
 		const { data: fileData, error: fileError } = await supabase
@@ -178,7 +194,7 @@ export async function HEAD(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('id', fileId)
+			.eq('id', normalizedFileId)
 			.eq('messages.conversation_participants.user_id', userId)
 			.single();
 
@@ -217,6 +233,10 @@ export async function POST(request, { params } = {}) {
 
 		const userId = user.id;
 		const { fileId } = await resolveRouteParams(params);
+		const normalizedFileId = normalizeFileId(fileId);
+		if (!normalizedFileId) {
+			return missingFileIdResponse();
+		}
 
 		console.log(`📁 [FILE-INFO] Info request from user: ${userId} for file: ${fileId}`);
 
@@ -237,7 +257,7 @@ export async function POST(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('id', fileId)
+			.eq('id', normalizedFileId)
 			.eq('messages.conversation_participants.user_id', userId)
 			.single();
 

--- a/src/app/api/files/[fileId]/route.test.js
+++ b/src/app/api/files/[fileId]/route.test.js
@@ -57,6 +57,19 @@ describe('/api/files/[fileId]', () => {
 		});
 	});
 
+	it('rejects blank file ids before querying file metadata', async () => {
+		const { HEAD } = await import('./route.js');
+		const response = await HEAD(new Request('https://qrypt.chat/api/files/%20'), {
+			params: Promise.resolve({ fileId: '   ' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'File ID is required' });
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.eq).not.toHaveBeenCalled();
+	});
+
 	it('resolves async route params for HEAD metadata requests', async () => {
 		const { HEAD } = await import('./route.js');
 		const response = await HEAD(new Request('https://qrypt.chat/api/files/file-1'), {


### PR DESCRIPTION
## Summary
- Normalize file route ids before querying encrypted file metadata.
- Return a 400 response for missing or whitespace-only file ids in GET, HEAD, and POST handlers.
- Add a regression test proving blank ids are rejected before metadata queries run.

## Validation
- `node --check src/app/api/files/[fileId]/route.js`
- `node --check src/app/api/files/[fileId]/route.test.js`
- `git diff --check`

I also attempted the focused Vitest file, but this checkout fails before test collection because `@vitejs/plugin-react` imports Vite `./internal`, which is not exported by the installed Vite package in this Windows/Node environment. The regression test is included for the normal CI/runtime.