### PR TITLE
fix(files): reject blank message file ids

### DIFF
--- a/src/app/api/files/message/[messageId]/route.js
+++ b/src/app/api/files/message/[messageId]/route.js
@@ -2,10 +2,15 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase.js';
 
+function normalizeMessageId(messageId) {
+	return typeof messageId === 'string' ? messageId.trim() : '';
+}
+
 export async function GET(request, { params } = {}) {
 	try {
 		const { messageId } = (await params) || {};
-		if (!messageId) {
+		const normalizedMessageId = normalizeMessageId(messageId);
+		if (!normalizedMessageId) {
 			return NextResponse.json({ error: 'Message ID is required' }, { status: 400 });
 		}
 
@@ -57,7 +62,7 @@ export async function GET(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('message_id', messageId)
+			.eq('message_id', normalizedMessageId)
 			.eq('messages.conversations.conversation_participants.user_id', userId);
 
 		if (filesError) {

--- a/src/app/api/files/message/[messageId]/route.test.js
+++ b/src/app/api/files/message/[messageId]/route.test.js
@@ -79,4 +79,14 @@ describe('GET /api/files/message/[messageId]', () => {
 		expect(response.status).toBe(400);
 		expect(mocks.authGetUser).not.toHaveBeenCalled();
 	});
+
+	it('rejects blank message ids before auth work', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/files/message/%20'), {
+			params: Promise.resolve({ messageId: '   ' })
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- Normalize `messageId` in the message-files API route before validation and database filtering.
- Reject blank/whitespace-only message ids before doing auth or Supabase work.
- Add regression coverage for whitespace-only route params.

## Validation
- `git diff --check`

I attempted `pnpm vitest run src/app/api/files/message/[messageId]/route.test.js`, but this Windows checkout stops during dependency preparation because the package `postinstall` script uses POSIX shell commands (`command -v ... || true`). I also attempted direct Vitest execution with `node node_modules\vitest\vitest.mjs run "src/app/api/files/message/[messageId]/route.test.js"`, but the local Vitest config fails to load because `@vitejs/plugin-react` imports `vite/internal`, which is not exported by the installed Vite package. I did not modify dependency files.