### PR TITLE
fix(crypto): reject blank public key user ids

### DIFF
--- a/src/app/api/crypto/public-keys/route.js
+++ b/src/app/api/crypto/public-keys/route.js
@@ -14,6 +14,10 @@ function getServiceRoleClient() {
 	return supabaseServiceRole;
 }
 
+function normalizeUserId(userId) {
+	return typeof userId === 'string' ? userId.trim() : '';
+}
+
 // Create regular client for JWT validation
 const supabaseClient = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
@@ -105,7 +109,7 @@ export async function GET(request) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const userId = url.searchParams.get('user_id');
+		const userId = normalizeUserId(url.searchParams.get('user_id'));
 		if (!userId) {
 			return NextResponse.json({ error: 'Missing user_id parameter' }, { status: 400 });
 		}

--- a/src/app/api/crypto/public-keys/route.test.js
+++ b/src/app/api/crypto/public-keys/route.test.js
@@ -82,4 +82,21 @@ describe('public key cookie authentication', () => {
 		expect(body).toEqual({ public_key: 'public-key', user_id: 'target-user-id' });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
 	});
+
+	it('rejects blank user ids before looking up a target public key', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/crypto/public-keys?user_id=%20%20%20', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')}`
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing user_id parameter' });
+		expect(mocks.serviceFrom).toHaveBeenCalledTimes(1);
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- Normalize the public-key `user_id` query parameter before validation.
- Return the existing missing-parameter 400 response for whitespace-only ids instead of doing a target lookup.
- Add regression coverage to ensure blank ids do not call the public-key RPC.

## Validation
- `git diff --check`
- `node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/crypto/public-keys/route.test.js"` (2 tests passed)

I used the same temporary minimal Vitest config needed locally because the repo's default Vitest config currently fails to load through the installed Vite/plugin combination; no dependency files were modified.