### PR TITLE
fix(conversations): reject blank archive ids

### DIFF
--- a/src/app/api/conversations/archive/route.js
+++ b/src/app/api/conversations/archive/route.js
@@ -6,9 +6,14 @@
 import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/api/middleware/auth.js';
 
+function normalizeConversationId(conversationId) {
+	return typeof conversationId === 'string' ? conversationId.trim() : '';
+}
+
 export const POST = withAuth(async ({ request, locals }) => {
 	try {
-		const { conversationId } = await request.json();
+		const { conversationId: rawConversationId } = await request.json();
+		const conversationId = normalizeConversationId(rawConversationId);
 
 		if (!conversationId) {
 			return NextResponse.json({ error: 'Missing conversationId' }, { status: 400 });

--- a/src/app/api/conversations/archive/route.test.js
+++ b/src/app/api/conversations/archive/route.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	rpc: vi.fn()
+}));
+
+vi.mock('@/lib/api/middleware/auth.js', () => ({
+	withAuth: (handler) => (request, context) =>
+		handler({
+			request,
+			locals: {
+				supabase: {
+					rpc: mocks.rpc
+				},
+				user: { id: 'auth-user-id' }
+			},
+			context
+		})
+}));
+
+function createRequest(conversationId) {
+	return {
+		json: vi.fn().mockResolvedValue({ conversationId })
+	};
+}
+
+describe('conversation archive routes', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		mocks.rpc.mockResolvedValue({ data: true, error: null });
+	});
+
+	it('trims conversation ids before archiving', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(createRequest('  conversation-1  '));
+
+		expect(response.status).toBe(200);
+		expect(mocks.rpc).toHaveBeenCalledWith('archive_conversation', {
+			conversation_uuid: 'conversation-1',
+			user_uuid: 'auth-user-id'
+		});
+	});
+
+	it('rejects blank archive conversation ids before calling the database', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(createRequest('   '));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing conversationId' });
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank unarchive conversation ids before calling the database', async () => {
+		const { POST } = await import('../unarchive/route.js');
+		const response = await POST(createRequest('   '));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing conversationId' });
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/api/conversations/unarchive/route.js
+++ b/src/app/api/conversations/unarchive/route.js
@@ -6,9 +6,14 @@
 import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/api/middleware/auth.js';
 
+function normalizeConversationId(conversationId) {
+	return typeof conversationId === 'string' ? conversationId.trim() : '';
+}
+
 export const POST = withAuth(async ({ request, locals }) => {
 	try {
-		const { conversationId } = await request.json();
+		const { conversationId: rawConversationId } = await request.json();
+		const conversationId = normalizeConversationId(rawConversationId);
 
 		if (!conversationId) {
 			return NextResponse.json({ error: 'Missing conversationId' }, { status: 400 });


### PR DESCRIPTION
## Summary
- Trim archive and unarchive `conversationId` values before passing them to RPC calls.
- Return the existing missing-id 400 response for whitespace-only ids.
- Add regression coverage for archive/unarchive blank ids and trimmed valid ids.

## Validation
- `git diff --check`
- `node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/conversations/archive/route.test.js"` (3 tests passed)

I used the same temporary minimal Vitest config needed locally because the repo's default Vitest config currently fails to load through the installed Vite/plugin combination; no dependency files were modified.