### PR TITLE
fix(users): skip empty sanitized searches

### DIFF
--- a/src/app/api/users/search/route.js
+++ b/src/app/api/users/search/route.js
@@ -29,6 +29,10 @@ export async function GET(request, { params } = {}) {
 			.replace(/\(/g, '')      // remove open parens (PostgREST operators)
 			.replace(/\)/g, '')      // remove close parens
 			.replace(/\./g, '');     // remove dots (PostgREST column separator)
+
+		if (sanitizedQuery.trim().length < 1) {
+			return NextResponse.json({ users: [] });
+		}
 		
 		// Enhanced fuzzy search across multiple fields with relevance scoring
 		// Search by username, display_name (full name), phone_number, and unique_identifier

--- a/src/app/api/users/search/route.test.js
+++ b/src/app/api/users/search/route.test.js
@@ -42,4 +42,15 @@ describe('user search', () => {
 		expect(response.status).toBe(200);
 		expect(mocks.neq).toHaveBeenCalledWith('auth_user_id', 'auth-user-1');
 	});
+
+	it('does not query users when sanitized search text is empty', async () => {
+		const { GET } = await import('./route.js');
+
+		const response = await GET(new Request('https://example.com/api/users/search?q=...'));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ users: [] });
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return an empty result when a user search query becomes empty after sanitization
- avoid issuing broad Supabase `ilike %%` style searches for punctuation-only input
- add focused route coverage for the sanitized-empty case

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/users/search/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.