### PR TITLE
fix(users): trim profile username params

### DIFF
--- a/src/app/api/users/by-username/[username]/route.js
+++ b/src/app/api/users/by-username/[username]/route.js
@@ -4,7 +4,8 @@ import { getServiceRoleClient } from '@/lib/supabase/service-role.js';
 export async function GET(request, { params } = {}) {
   try {
     const { username } = (await params) || {};
-    if (!username) {
+    const normalizedUsername = username?.trim().toLowerCase();
+    if (!normalizedUsername) {
       return NextResponse.json({ error: 'Username required' }, { status: 400 });
     }
 
@@ -18,7 +19,7 @@ export async function GET(request, { params } = {}) {
     const { data, error } = await supabase
       .from('users')
       .select('id, username, display_name, avatar_url, bio, unique_identifier')
-      .eq('username', username.toLowerCase())
+      .eq('username', normalizedUsername)
       .single();
 
     if (error || !data) {

--- a/src/app/api/users/by-username/[username]/route.test.js
+++ b/src/app/api/users/by-username/[username]/route.test.js
@@ -5,8 +5,8 @@ const mocks = vi.hoisted(() => ({
 	eq: vi.fn()
 }));
 
-vi.mock('@/lib/supabase.js', () => ({
-	createSupabaseServerClient: vi.fn(async () => ({
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	getServiceRoleClient: vi.fn(() => ({
 		from: mocks.from
 	}))
 }));
@@ -50,10 +50,30 @@ describe('GET /api/users/by-username/[username]', () => {
 		expect(mocks.eq).toHaveBeenCalledWith('username', 'alice');
 	});
 
+	it('trims usernames before database lookup', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-username/%20Alice%20'), {
+			params: Promise.resolve({ username: ' Alice ' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(mocks.eq).toHaveBeenCalledWith('username', 'alice');
+	});
+
 	it('rejects missing usernames before database work', async () => {
 		const { GET } = await import('./route.js');
 		const response = await GET(new Request('https://qrypt.chat/api/users/by-username/'), {
 			params: Promise.resolve({})
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank usernames before database work', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/users/by-username/%20%20'), {
+			params: Promise.resolve({ username: '  ' })
 		});
 
 		expect(response.status).toBe(400);


### PR DESCRIPTION
## Summary
- trim and lowercase public profile username route params before lookup
- reject whitespace-only usernames before database work
- update route tests to cover trimming and blank username handling

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/users/by-username/[username]/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.