### PR TITLE
fix(files): trim encrypted file ids

### DIFF
--- a/src/app/api/files/[fileId]/encrypted/route.js
+++ b/src/app/api/files/[fileId]/encrypted/route.js
@@ -5,7 +5,8 @@ import { createSupabaseServerClient } from '@/lib/supabase.js';
 export async function GET(request, { params } = {}) {
 	try {
 		const { fileId } = (await params) || {};
-		if (!fileId) {
+		const normalizedFileId = fileId?.trim();
+		if (!normalizedFileId) {
 			return NextResponse.json({ error: 'File ID is required' }, { status: 400 });
 		}
 
@@ -55,7 +56,7 @@ export async function GET(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('id', fileId)
+			.eq('id', normalizedFileId)
 			.eq('messages.conversations.conversation_participants.user_id', userId)
 			.single();
 

--- a/src/app/api/files/[fileId]/encrypted/route.test.js
+++ b/src/app/api/files/[fileId]/encrypted/route.test.js
@@ -90,10 +90,30 @@ describe('GET /api/files/[fileId]/encrypted', () => {
 		expect(mocks.download).toHaveBeenCalledWith('encrypted/file-1');
 	});
 
+	it('trims file ids before filtering encrypted files', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/files/%20file-1%20/encrypted'), {
+			params: Promise.resolve({ fileId: ' file-1 ' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(mocks.filesEq).toHaveBeenCalledWith('id', 'file-1');
+	});
+
 	it('rejects missing file ids before auth work', async () => {
 		const { GET } = await import('./route.js');
 		const response = await GET(new Request('https://qrypt.chat/api/files//encrypted'), {
 			params: Promise.resolve({})
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank file ids before auth work', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/files/%20%20/encrypted'), {
+			params: Promise.resolve({ fileId: '  ' })
 		});
 
 		expect(response.status).toBe(400);


### PR DESCRIPTION
## Summary
- trim encrypted file route params before validation and lookup
- reject whitespace-only file ids before authentication or database work
- add focused route coverage for trimmed and blank file ids

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/files/[fileId]/encrypted/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.