### PR TITLE
fix(files): trim message file ids

### DIFF
--- a/src/app/api/files/message/[messageId]/route.js
+++ b/src/app/api/files/message/[messageId]/route.js
@@ -5,7 +5,8 @@ import { createSupabaseServerClient } from '@/lib/supabase.js';
 export async function GET(request, { params } = {}) {
 	try {
 		const { messageId } = (await params) || {};
-		if (!messageId) {
+		const normalizedMessageId = messageId?.trim();
+		if (!normalizedMessageId) {
 			return NextResponse.json({ error: 'Message ID is required' }, { status: 400 });
 		}
 
@@ -57,7 +58,7 @@ export async function GET(request, { params } = {}) {
 					)
 				)
 			`)
-			.eq('message_id', messageId)
+			.eq('message_id', normalizedMessageId)
 			.eq('messages.conversations.conversation_participants.user_id', userId);
 
 		if (filesError) {

--- a/src/app/api/files/message/[messageId]/route.test.js
+++ b/src/app/api/files/message/[messageId]/route.test.js
@@ -70,10 +70,30 @@ describe('GET /api/files/message/[messageId]', () => {
 		expect(mocks.filesEq).toHaveBeenCalledWith('message_id', 'message-1');
 	});
 
+	it('trims message ids before filtering files', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/files/message/%20message-1%20'), {
+			params: Promise.resolve({ messageId: ' message-1 ' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(mocks.filesEq).toHaveBeenCalledWith('message_id', 'message-1');
+	});
+
 	it('rejects missing message ids before auth work', async () => {
 		const { GET } = await import('./route.js');
 		const response = await GET(new Request('https://qrypt.chat/api/files/message/'), {
 			params: Promise.resolve({})
+		});
+
+		expect(response.status).toBe(400);
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank message ids before auth work', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/files/message/%20%20'), {
+			params: Promise.resolve({ messageId: '  ' })
 		});
 
 		expect(response.status).toBe(400);


### PR DESCRIPTION
## Summary
- trim message file route params before validation and lookup
- reject whitespace-only message ids before authentication or database work
- add focused route coverage for trimmed and blank message ids

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/files/message/[messageId]/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.