### PR TITLE
fix(messages): trim chat message ids

### DIFF
--- a/src/app/api/chat/messages/[id]/route.js
+++ b/src/app/api/chat/messages/[id]/route.js
@@ -55,8 +55,9 @@ async function authenticateUser(request) {
 export async function GET(request, { params } = {}) {
 	try {
 		const { id: messageId } = await resolveRouteParams(params);
+		const normalizedMessageId = messageId?.trim();
 		
-		if (!messageId) {
+		if (!normalizedMessageId) {
 			return NextResponse.json({ error: 'Message ID is required' }, { status: 400 });
 		}
 		
@@ -90,7 +91,7 @@ export async function GET(request, { params } = {}) {
 				sender:users!messages_sender_id_fkey(id, username, display_name, avatar_url),
 				message_recipients!inner(encrypted_content)
 			`)
-			.eq('id', messageId)
+			.eq('id', normalizedMessageId)
 			.eq('message_recipients.recipient_user_id', userId)
 			.single();
 		

--- a/src/app/api/chat/messages/[id]/route.test.js
+++ b/src/app/api/chat/messages/[id]/route.test.js
@@ -82,10 +82,35 @@ describe('GET /api/chat/messages/[id]', () => {
 		expect(mocks.messageEq).toHaveBeenCalledWith('id', 'message-1');
 	});
 
+	it('trims message ids before fetching the message', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/chat/messages/%20message-1%20', {
+				headers: { cookie: 'sb-access-token=valid-token' }
+			}),
+			{ params: Promise.resolve({ id: ' message-1 ' }) }
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.messageEq).toHaveBeenCalledWith('id', 'message-1');
+	});
+
 	it('rejects missing async route params before authentication', async () => {
 		const { GET } = await import('./route.js');
 		const response = await GET(new Request('https://qrypt.chat/api/chat/messages/'), {
 			params: Promise.resolve({})
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Message ID is required' });
+		expect(mocks.authGetUser).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank message ids before authentication', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(new Request('https://qrypt.chat/api/chat/messages/%20%20'), {
+			params: Promise.resolve({ id: '  ' })
 		});
 		const body = await response.json();
 


### PR DESCRIPTION
## Summary
- trim chat message route params before validation and lookup
- reject whitespace-only message ids before authentication or database work
- add focused route coverage for trimmed and blank message ids

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/chat/messages/[id]/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.