### PR TITLE
fix(crypto): trim public key user ids

### DIFF
--- a/src/app/api/crypto/public-keys/route.js
+++ b/src/app/api/crypto/public-keys/route.js
@@ -99,15 +99,15 @@ async function authenticateUser(request) {
 export async function GET(request) {
 	const url = new URL(request.url);
 	try {
+		const userId = url.searchParams.get('user_id')?.trim();
+		if (!userId) {
+			return NextResponse.json({ error: 'Missing user_id parameter' }, { status: 400 });
+		}
+
 		// Authenticate user
 		const { user, error: authError } = await authenticateUser(request);
 		if (authError || !user) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-		}
-
-		const userId = url.searchParams.get('user_id');
-		if (!userId) {
-			return NextResponse.json({ error: 'Missing user_id parameter' }, { status: 400 });
 		}
 
 		// Get the user's auth_user_id from the internal user ID

--- a/src/app/api/crypto/public-keys/route.test.js
+++ b/src/app/api/crypto/public-keys/route.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
 	authGetUser: vi.fn(),
 	serviceFrom: vi.fn(),
+	userEq: vi.fn(),
 	rpc: vi.fn()
 }));
 
@@ -32,7 +33,7 @@ function createUsersQuery() {
 			selected = fields;
 			return query;
 		}),
-		eq: vi.fn(() => query),
+		eq: mocks.userEq,
 		single: vi.fn(() => {
 			if (selected.includes('id, auth_user_id')) {
 				return Promise.resolve({
@@ -46,6 +47,7 @@ function createUsersQuery() {
 			});
 		})
 	};
+	mocks.userEq.mockReturnValue(query);
 	return query;
 }
 
@@ -81,5 +83,37 @@ describe('public key cookie authentication', () => {
 		expect(response.status).toBe(200);
 		expect(body).toEqual({ public_key: 'public-key', user_id: 'target-user-id' });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+
+	it('trims user_id before public key lookup and response', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/crypto/public-keys?user_id=%20target-user-id%20', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')}`
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ public_key: 'public-key', user_id: 'target-user-id' });
+		expect(mocks.userEq).toHaveBeenCalledWith('id', 'target-user-id');
+	});
+
+	it('rejects blank user_id before public key lookup', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/crypto/public-keys?user_id=%20%20', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')}`
+				}
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing user_id parameter' });
+		expect(mocks.serviceFrom).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- trim `user_id` query params before public key lookup and response
- reject blank `user_id` values before authentication or service-role database work
- add focused route coverage for trimmed and blank user ids

## Tests
- `node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/crypto/public-keys/route.test.js"`
- `git diff --check`

Note: I used the minimal Vitest config already present locally because the repo's default Vitest setup imports `@vitejs/plugin-react`, which currently fails against the installed Vite package export map in this checkout.