### PR TITLE
fix(profile): validate trimmed bio length

### DIFF
--- a/src/app/api/profile/update/route.js
+++ b/src/app/api/profile/update/route.js
@@ -54,17 +54,19 @@ export async function POST(request, { params } = {}) {
 			return NextResponse.json({ error: 'Website must be a string' }, { status: 400 });
 		}
 
+		const trimmedBio = typeof bio === 'string' ? bio.trim() : undefined;
+		const trimmedWebsite = typeof website === 'string' ? website.trim() : undefined;
+
 		// Validate bio length
-		if (bio && bio.length > 500) {
+		if (trimmedBio && trimmedBio.length > 500) {
 			return NextResponse.json({ error: 'Bio must be 500 characters or less' }, { status: 400 });
 		}
 
 		// Validate website URL format if provided
-		if (website && website.trim()) {
-			const websiteUrl = website.trim();
+		if (trimmedWebsite) {
 			// Basic URL validation - allow with or without protocol
 			const urlPattern = /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/i;
-			if (!urlPattern.test(websiteUrl)) {
+			if (!urlPattern.test(trimmedWebsite)) {
 				return NextResponse.json({ error: 'Please enter a valid website URL' }, { status: 400 });
 			}
 		}
@@ -72,8 +74,8 @@ export async function POST(request, { params } = {}) {
 		// Prepare update data
 		const updateData = {
 			updated_at: new Date().toISOString(),
-			...(bio !== undefined && { bio: bio.trim() || null }),
-			...(website !== undefined && { website: website.trim() || null })
+			...(bio !== undefined && { bio: trimmedBio || null }),
+			...(website !== undefined && { website: trimmedWebsite || null })
 		};
 
 		// Update user profile using RLS - the policy ensures only the authenticated user can update their own profile

--- a/src/app/api/profile/update/route.test.js
+++ b/src/app/api/profile/update/route.test.js
@@ -3,27 +3,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
 	getUser: vi.fn(),
 	setSession: vi.fn(),
+	updateProfile: vi.fn(() => ({
+		eq: vi.fn(() => ({
+			select: vi.fn(() => ({
+				data: [{
+					id: 'row-1',
+					username: 'alice',
+					display_name: 'Alice',
+					avatar_url: null,
+					bio: 'hello',
+					website: null
+				}],
+				error: null
+			}))
+		}))
+	})),
 	createSupabaseServerClient: vi.fn(() => ({
 		auth: {
 			getUser: mocks.getUser,
 			setSession: mocks.setSession
 		},
 		from: vi.fn(() => ({
-			update: vi.fn(() => ({
-				eq: vi.fn(() => ({
-					select: vi.fn(() => ({
-						data: [{
-							id: 'row-1',
-							username: 'alice',
-							display_name: 'Alice',
-							avatar_url: null,
-							bio: 'hello',
-							website: null
-						}],
-						error: null
-					}))
-				}))
-			}))
+			update: mocks.updateProfile
 		}))
 	}))
 }));
@@ -32,11 +33,11 @@ vi.mock('@/lib/supabase.js', () => ({
 	createSupabaseServerClient: mocks.createSupabaseServerClient
 }));
 
-function profileRequest(authorization) {
+function profileRequest(authorization, body = { bio: 'hello' }) {
 	return new Request('https://example.com/api/profile/update', {
 		method: 'POST',
 		headers: authorization ? { authorization } : {},
-		body: JSON.stringify({ bio: 'hello' })
+		body: JSON.stringify(body)
 	});
 }
 
@@ -75,5 +76,19 @@ describe('profile update bearer authentication', () => {
 		expect(body.error).toBe('Missing or invalid authorization header');
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.getUser).not.toHaveBeenCalled();
+	});
+
+	it('validates bio length after trimming surrounding whitespace', async () => {
+		const { POST } = await import('./route.js');
+		const bio = `  ${'a'.repeat(500)}  `;
+
+		const response = await POST(profileRequest('Bearer access-token-123', { bio }));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.success).toBe(true);
+		expect(mocks.updateProfile).toHaveBeenCalledWith(expect.objectContaining({
+			bio: 'a'.repeat(500)
+		}));
 	});
 });


### PR DESCRIPTION
## Summary
- normalize profile bio and website once before validation and storage
- validate the bio length after trimming surrounding whitespace, matching the value that will be saved
- add regression coverage for a 500-character bio with surrounding spaces

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/profile/update/route.test.js" (3 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled