### PR TITLE
fix(auth): validate salt payload strings

### DIFF
--- a/src/app/api/auth/salt/route.js
+++ b/src/app/api/auth/salt/route.js
@@ -102,9 +102,10 @@ export async function POST(request) {
 		}
 
 		const { salt } = await request.json();
-		if (!salt) {
+		if (typeof salt !== 'string' || !salt.trim()) {
 			return NextResponse.json({ error: 'Missing salt' }, { status: 400 });
 		}
+		const normalizedSalt = salt.trim();
 
 		// Verify the authenticated user has a record and look up their phone.
 		const { data: existing } = await getServiceRoleClient()
@@ -124,7 +125,7 @@ export async function POST(request) {
 
 		const { error } = await getServiceRoleClient()
 			.from('users')
-			.update({ salt })
+			.update({ salt: normalizedSalt })
 			.eq('auth_user_id', user.id);
 
 		if (error) {
@@ -132,7 +133,7 @@ export async function POST(request) {
 			return NextResponse.json({ error: 'Failed to store salt' }, { status: 500 });
 		}
 
-		return NextResponse.json({ salt, existing: false });
+		return NextResponse.json({ salt: normalizedSalt, existing: false });
 	} catch (error) {
 		console.error('Salt POST error:', error);
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/auth/salt/route.test.js
+++ b/src/app/api/auth/salt/route.test.js
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
 	authGetUser: vi.fn(),
-	serviceFrom: vi.fn()
+	serviceFrom: vi.fn(),
+	updateUser: vi.fn(() => ({
+		eq: vi.fn(() => Promise.resolve({ error: null }))
+	}))
 }));
 
 vi.mock('@supabase/supabase-js', () => ({
@@ -27,6 +30,7 @@ function createUsersQuery() {
 	const query = {
 		select: vi.fn(() => query),
 		eq: vi.fn(() => query),
+		update: mocks.updateUser,
 		single: vi.fn(() =>
 			Promise.resolve({
 				data: { salt: 'stored-salt' },
@@ -35,6 +39,14 @@ function createUsersQuery() {
 		)
 	};
 	return query;
+}
+
+function postSaltRequest(body, headers = { authorization: 'Bearer access-token' }) {
+	return new Request('https://qrypt.chat/api/auth/salt', {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(body)
+	});
 }
 
 describe('salt cookie authentication', () => {
@@ -99,5 +111,35 @@ describe('salt cookie authentication', () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.authGetUser).toHaveBeenCalledWith('cookie-token');
+	});
+
+	it('rejects non-string salts before querying the user record', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(postSaltRequest({ salt: { value: 'abc' } }));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Missing salt');
+		expect(mocks.serviceFrom).not.toHaveBeenCalled();
+	});
+
+	it('trims new salts before storing and returning them', async () => {
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table !== 'users') throw new Error(`Unexpected table: ${table}`);
+			const query = createUsersQuery();
+			query.single.mockResolvedValueOnce({
+				data: { salt: null, phone_number: '+15551234567' },
+				error: null
+			});
+			return query;
+		});
+
+		const { POST } = await import('./route.js');
+		const response = await POST(postSaltRequest({ salt: '  client-salt  ' }));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ salt: 'client-salt', existing: false });
+		expect(mocks.updateUser).toHaveBeenCalledWith({ salt: 'client-salt' });
 	});
 });


### PR DESCRIPTION
## Summary
- reject missing, blank, or non-string salt payloads before user-record lookup/update
- trim valid salts before storing and returning them
- add focused POST regression coverage for invalid object payloads and trimmed valid salts

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/salt/route.test.js" (5 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled