### PR TITLE
fix(auth): handle malformed backup pin JSON

### DIFF
--- a/src/app/api/auth/backup-pin/route.js
+++ b/src/app/api/auth/backup-pin/route.js
@@ -145,7 +145,14 @@ export async function POST(request) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const { pin } = await request.json();
+		let body;
+		try {
+			body = await request.json();
+		} catch {
+			return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+		}
+
+		const { pin } = body;
 
 		if (!pin || typeof pin !== 'string' || pin.length < 6 || pin.length > 12) {
 			return NextResponse.json({ error: 'PIN must be 6-12 digits' }, { status: 400 });

--- a/src/app/api/auth/backup-pin/route.test.js
+++ b/src/app/api/auth/backup-pin/route.test.js
@@ -100,4 +100,17 @@ describe('backup PIN cookie authentication', () => {
 		expect(response.status).toBe(200);
 		expect(mocks.authGetUser).toHaveBeenCalledWith('cookie-token');
 	});
+
+	it('returns 400 for malformed JSON instead of a generic 500', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST({
+			headers: new Headers({ authorization: 'Bearer access-token' }),
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.serviceFrom).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a 400 response for malformed backup PIN JSON payloads
- avoid treating client JSON syntax errors as generic internal server errors
- add focused regression coverage that verifies no database work runs for malformed JSON

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/backup-pin/route.test.js" (4 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled