### PR TITLE
fix(auth): handle malformed key backup JSON

### DIFF
--- a/src/app/api/auth/key-backup/route.js
+++ b/src/app/api/auth/key-backup/route.js
@@ -147,7 +147,14 @@ export async function PUT(request) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const { encrypted_keys } = await request.json();
+		let body;
+		try {
+			body = await request.json();
+		} catch {
+			return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+		}
+
+		const { encrypted_keys } = body;
 
 		if (!encrypted_keys || typeof encrypted_keys !== 'string') {
 			return NextResponse.json({ error: 'Missing or invalid encrypted_keys' }, { status: 400 });

--- a/src/app/api/auth/key-backup/route.test.js
+++ b/src/app/api/auth/key-backup/route.test.js
@@ -108,4 +108,17 @@ describe('key backup cookie authentication', () => {
 		expect(response.status).toBe(200);
 		expect(mocks.authGetUser).toHaveBeenCalledWith('cookie-token');
 	});
+
+	it('returns 400 for malformed JSON instead of a generic 500', async () => {
+		const { PUT } = await import('./route.js');
+		const response = await PUT({
+			headers: new Headers({ authorization: 'Bearer access-token' }),
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.serviceFrom).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a 400 response for malformed key-backup JSON payloads
- avoid treating client JSON syntax errors as generic internal server errors
- add focused regression coverage that verifies no storage/database work runs for malformed JSON

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/key-backup/route.test.js" (4 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled