### PR TITLE
fix(settings): handle malformed disappearing messages JSON

### DIFF
--- a/src/app/api/settings/disappearing-messages/route.js
+++ b/src/app/api/settings/disappearing-messages/route.js
@@ -75,7 +75,14 @@ export async function PUT(request) {
 			return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
 		}
 
-		const { default_message_retention_days } = await request.json();
+		let body;
+		try {
+			body = await request.json();
+		} catch {
+			return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+		}
+
+		const { default_message_retention_days } = body;
 
 		// Validate input
 		if (typeof default_message_retention_days !== 'number' || default_message_retention_days < 0) {

--- a/src/app/api/settings/disappearing-messages/route.test.js
+++ b/src/app/api/settings/disappearing-messages/route.test.js
@@ -130,4 +130,17 @@ describe('settings disappearing messages authentication', () => {
 		expect(mocks.authGetUser).toHaveBeenCalledWith('valid-token');
 		expect(mocks.updateEq).toHaveBeenCalledWith('auth_user_id', 'auth-user-id');
 	});
+
+	it('returns 400 for malformed PUT JSON instead of a generic 500', async () => {
+		const { PUT } = await import('./route.js');
+		const response = await PUT({
+			headers: new Headers({ authorization: 'Bearer valid-token' }),
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a 400 response for malformed disappearing-message settings JSON
- avoid treating client JSON syntax errors as generic internal server errors
- add focused regression coverage that verifies no profile update runs for malformed JSON

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/settings/disappearing-messages/route.test.js" (6 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled