### PR TITLE
fix(conversations): handle malformed disappearing settings JSON

### DIFF
--- a/src/app/api/conversations/[id]/disappearing-messages/route.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/route.js
@@ -178,7 +178,14 @@ export async function PUT(request, { params } = {}) {
       return NextResponse.json({ error: 'Missing conversation ID' }, { status: 400 });
     }
 
-    const { disappear_seconds, start_on } = await request.json();
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { disappear_seconds, start_on } = body;
 
     // Validate input
     if (typeof disappear_seconds !== 'number' || disappear_seconds < 0) {

--- a/src/app/api/conversations/[id]/disappearing-messages/route.test.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/route.test.js
@@ -124,4 +124,26 @@ describe('/api/conversations/[id]/disappearing-messages', () => {
 		expect(mocks.participantEq).toHaveBeenCalledWith('conversation_id', 'conversation-1');
 		expect(mocks.updateEq).toHaveBeenCalledWith('conversation_id', 'conversation-1');
 	});
+
+	it('returns 400 for malformed PUT JSON before participant lookup', async () => {
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			if (table === 'conversation_participants') throw new Error('Participant query should not run');
+			throw new Error(`Unexpected table: ${table}`);
+		});
+
+		const { PUT } = await import('./route.js');
+		const response = await PUT({
+			headers: new Headers({ cookie: 'sb-access-token=valid-token' }),
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		}, {
+			params: Promise.resolve({ id: 'conversation-1' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.participantEq).not.toHaveBeenCalled();
+		expect(mocks.updateEq).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a 400 response for malformed per-conversation disappearing-message JSON
- avoid treating client JSON syntax errors as generic internal server errors
- add focused regression coverage that verifies participant lookup/update does not run for malformed JSON

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/conversations/[id]/disappearing-messages/route.test.js" (3 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled