### PR TITLE
fix(auth): reuse parsed debug sms body

### DIFF
--- a/src/app/api/auth/debug-sms/route.js
+++ b/src/app/api/auth/debug-sms/route.js
@@ -39,7 +39,14 @@ export async function POST(request, { params } = {}) {
 
 		
 	try {
-		const { phoneNumber, action = 'diagnose' } = await request.json();
+		let body;
+		try {
+			body = await request.json();
+		} catch {
+			return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+		}
+
+		const { phoneNumber, action = 'diagnose', verificationCode } = body;
 
 		if (!phoneNumber) {
 			return NextResponse.json(
@@ -64,7 +71,6 @@ export async function POST(request, { params } = {}) {
 				});
 
 			case 'test-verify':
-				const { verificationCode } = await request.json();
 				if (!verificationCode) {
 					return NextResponse.json(
 						{ error: 'Verification code is required for verify test' },

--- a/src/app/api/auth/debug-sms/route.test.js
+++ b/src/app/api/auth/debug-sms/route.test.js
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
 	getUser: vi.fn(),
 	runDiagnostics: vi.fn(),
+	testSMSVerification: vi.fn(),
 	SMSAuthDiagnostics: vi.fn(function SMSAuthDiagnostics(request) {
 		this.request = request;
 		this.logger = { getLogs: () => [] };
 		this.runDiagnostics = mocks.runDiagnostics;
+		this.testSMSVerification = mocks.testSMSVerification;
 	})
 }));
 
@@ -44,6 +46,11 @@ describe('SMS debug endpoint', () => {
 			issues: [],
 			logs: []
 		});
+		mocks.testSMSVerification.mockResolvedValue({
+			success: true,
+			error: null,
+			data: { verified: true }
+		});
 	});
 
 	it('uses the incoming request for authenticated POST diagnostics', async () => {
@@ -70,5 +77,33 @@ describe('SMS debug endpoint', () => {
 		expect(body.systemStatus).toBe('healthy');
 		expect(mocks.SMSAuthDiagnostics).toHaveBeenCalledWith(request);
 		expect(mocks.runDiagnostics).toHaveBeenCalledWith('+1234567890');
+	});
+
+	it('reuses the parsed POST body for verify diagnostics', async () => {
+		const { POST } = await import('./route.js');
+		const request = debugRequest('POST', {
+			phoneNumber: '+1234567890',
+			action: 'test-verify',
+			verificationCode: '123456'
+		});
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.success).toBe(true);
+		expect(mocks.testSMSVerification).toHaveBeenCalledWith('+1234567890', '123456');
+	});
+
+	it('returns 400 for malformed POST JSON instead of a generic 500', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST({
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.SMSAuthDiagnostics).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- parse the debug SMS POST body once and reuse it for test-verify requests
- prevent valid test-verify diagnostics from failing when the request body is read a second time
- return a 400 response for malformed debug SMS JSON payloads

## Validation
- git diff --check
- node node_modules\vitest\vitest.mjs run --config $env:TEMP\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/debug-sms/route.test.js" (4 tests)

## Billing
- uGig billable PR candidate: expected invoice $0.50 if accepted/merged
- Not counted as revenue until paid/settled