### PR TITLE
fix(files): validate upload completion metadata

### DIFF
--- a/src/app/api/files/upload-complete/route.js
+++ b/src/app/api/files/upload-complete/route.js
@@ -49,11 +49,21 @@ export async function POST(request, { params } = {}) {
 			return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
 		}
 
+		if (typeof metadata !== 'object' || Array.isArray(metadata)) {
+			console.error('UPLOAD-COMPLETE: Invalid metadata');
+			return NextResponse.json({ error: 'Invalid metadata' }, { status: 400 });
+		}
+
 		const { messageId, conversationId, encryptedMetadata } = metadata;
 
 		if (!messageId || !conversationId || !encryptedMetadata) {
 			console.error( '📁 [UPLOAD-COMPLETE] Missing metadata fields');
 			return NextResponse.json({ error: 'Missing metadata fields' }, { status: 400 });
+		}
+
+		if (typeof encryptedMetadata !== 'object' || Array.isArray(encryptedMetadata)) {
+			console.error('UPLOAD-COMPLETE: Invalid encrypted metadata');
+			return NextResponse.json({ error: 'Invalid encrypted metadata' }, { status: 400 });
 		}
 
 		// Get the internal user ID from the users table using auth_user_id

--- a/src/app/api/files/upload-complete/route.test.js
+++ b/src/app/api/files/upload-complete/route.test.js
@@ -66,4 +66,46 @@ describe('POST /api/files/upload-complete validation', () => {
 		expect(mocks.from).not.toHaveBeenCalled();
 		expect(mocks.broadcastToRoom).not.toHaveBeenCalled();
 	});
+
+	it('rejects non-object metadata before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				storagePath: 'auth-user-id/conversation-1/file-1',
+				fileId: 'file-1',
+				metadata: 'not-metadata'
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid metadata');
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.broadcastToRoom).not.toHaveBeenCalled();
+	});
+
+	it('rejects non-object encrypted metadata before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				storagePath: 'auth-user-id/conversation-1/file-1',
+				fileId: 'file-1',
+				metadata: {
+					messageId: 'message-1',
+					conversationId: 'conversation-1',
+					encryptedMetadata: 'not-a-recipient-map'
+				}
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid encrypted metadata');
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.broadcastToRoom).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject non-object upload completion metadata before profile and conversation lookups
- reject invalid encryptedMetadata maps before storage checks or broadcasts
- add focused regression coverage for both invalid metadata shapes

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/files/upload-complete/route.test.js"
- git diff --check

uGig billable bugfix candidate. Not counted as revenue until accepted, invoiced, and paid.