### PR TITLE
fix(messages): validate send metadata object

### DIFF
--- a/src/app/api/messages/send/route.js
+++ b/src/app/api/messages/send/route.js
@@ -41,6 +41,10 @@ export const POST = withAuth(async ({ request, locals }) => {
 			return NextResponse.json({ error: 'encryptedContents values must be encrypted content strings' }, { status: 400 });
 		}
 
+		if (metadata !== undefined && (typeof metadata !== 'object' || Array.isArray(metadata) || metadata === null)) {
+			return NextResponse.json({ error: 'metadata must be a JSON object' }, { status: 400 });
+		}
+
 		const { supabase, user: authUser } = locals;
 
 		// Get internal user ID from auth user ID

--- a/src/app/api/messages/send/route.test.js
+++ b/src/app/api/messages/send/route.test.js
@@ -80,4 +80,24 @@ describe('POST /api/messages/send validation', () => {
 		expect(body.error).toBe('encryptedContents values must be encrypted content strings');
 		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
 	});
+
+	it('rejects non-object metadata before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				conversationId: 'conversation-1',
+				encryptedContents: {
+					'user-1': 'encrypted-content'
+				},
+				metadata: 'not-json-object'
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('metadata must be a JSON object');
+		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject non-object send-message metadata before database work
- keep the existing default empty metadata object when metadata is omitted
- add focused regression coverage for invalid metadata payloads

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/messages/send/route.test.js"
- git diff --check

uGig billable bugfix candidate. Not counted as revenue until accepted, invoiced, and paid.