### PR TITLE
fix(keys): validate reset public key strings

### DIFF
--- a/src/app/api/keys/reset/route.js
+++ b/src/app/api/keys/reset/route.js
@@ -13,7 +13,7 @@ export async function POST(request, { params } = {}) {
 		// Get the request body
 		const { publicKey } = await request.json();
 
-		if (!publicKey) {
+		if (!publicKey || typeof publicKey !== 'string' || !publicKey.trim()) {
 			return NextResponse.json({ error: 'Missing required field: publicKey' }, { status: 400 });
 		}
 

--- a/src/app/api/keys/reset/route.test.js
+++ b/src/app/api/keys/reset/route.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	createSupabaseServerClient: vi.fn(),
+	createClient: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: mocks.createSupabaseServerClient
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: mocks.createClient
+}));
+
+describe('POST /api/keys/reset validation', () => {
+	it('rejects non-string public keys before auth or service clients', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST({
+			json: vi.fn().mockResolvedValue({
+				publicKey: { key: 'not-a-string' }
+			})
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Missing required field: publicKey');
+		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
+		expect(mocks.createClient).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- require reset publicKey payloads to be non-empty strings
- reject invalid publicKey shapes before auth and service clients
- add focused regression coverage for non-string public keys

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/keys/reset/route.test.js"
- git diff --check

uGig billable bugfix candidate. Not counted as revenue until accepted, invoiced, and paid.