### PR TITLE
fix(conversations): validate participant ids

### DIFF
--- a/src/app/api/conversations/create/route.js
+++ b/src/app/api/conversations/create/route.js
@@ -27,11 +27,22 @@ export const POST = withAuth(async ({ request, locals }) => {
 			return NextResponse.json({ error: 'Missing or invalid participantIds' }, { status: 400 });
 		}
 
+		const normalizedParticipantIds = participantIds.map((participantId) =>
+			typeof participantId === 'string' ? participantId.trim() : ''
+		);
+
+		if (
+			normalizedParticipantIds.length !== participantIds.length ||
+			normalizedParticipantIds.some((participantId) => participantId.length === 0)
+		) {
+			return NextResponse.json({ error: 'Invalid participantIds' }, { status: 400 });
+		}
+
 		const { supabase, user } = locals;
 
 		// For direct conversations, check if one already exists
-		if (!isGroup && participantIds.length === 1) {
-			const otherUserId = participantIds[0];
+		if (!isGroup && normalizedParticipantIds.length === 1) {
+			const otherUserId = normalizedParticipantIds[0];
 			
 			// Check for existing direct conversation
 			const { data: existing } = await supabase
@@ -64,7 +75,7 @@ export const POST = withAuth(async ({ request, locals }) => {
 		}
 
 		// Add participants
-		const allParticipants = [user.id, ...participantIds];
+		const allParticipants = [user.id, ...normalizedParticipantIds];
 		const participantInserts = allParticipants.map(userId => ({
 			conversation_id: conversation.id,
 			user_id: userId
@@ -83,7 +94,7 @@ export const POST = withAuth(async ({ request, locals }) => {
 		sseManager.joinRoom(user.id, conversation.id);
 
 		// Notify other participants
-		for (const participantId of participantIds) {
+		for (const participantId of normalizedParticipantIds) {
 			sseManager.sendToUser(participantId, MESSAGE_TYPES.CONVERSATION_CREATED, {
 				conversation
 			});

--- a/src/app/api/conversations/create/route.test.js
+++ b/src/app/api/conversations/create/route.test.js
@@ -61,4 +61,23 @@ describe('POST /api/conversations/create validation', () => {
 		expect(body.error).toBe('Request body must be a JSON object');
 		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
 	});
+
+	it('rejects blank participant ids before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				participantIds: ['  '],
+				isGroup: false
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid participantIds');
+		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
+		expect(mocks.mockJoinRoom).not.toHaveBeenCalled();
+		expect(mocks.mockSendToUser).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject blank or non-string participant IDs before conversation creation
- reuse trimmed participant IDs for direct-conversation lookup, inserts, and SSE notifications
- add a regression test that confirms invalid IDs stop before database or SSE work

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/conversations/create/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment