### PR TITLE
fix(profile): handle malformed update JSON

### DIFF
--- a/src/app/api/profile/update/route.js
+++ b/src/app/api/profile/update/route.js
@@ -16,7 +16,14 @@ function getBearerToken(authHeader) {
 
 export async function POST(request, { params } = {}) {
 	try {
-		const { bio, website } = await request.json();
+		let body;
+		try {
+			body = await request.json();
+		} catch {
+			return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+		}
+
+		const { bio, website } = body;
 
 		// Get authorization header
 		const authHeader = request.headers.get('authorization');

--- a/src/app/api/profile/update/route.test.js
+++ b/src/app/api/profile/update/route.test.js
@@ -76,4 +76,19 @@ describe('profile update bearer authentication', () => {
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.getUser).not.toHaveBeenCalled();
 	});
+
+	it('returns 400 for malformed JSON before authentication work', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST({
+			headers: new Headers({ authorization: 'Bearer access-token-123' }),
+			json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token'))
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
+		expect(mocks.getUser).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a 400 response for malformed profile update JSON instead of falling through to the generic 500 handler
- stop malformed requests before authentication/session/database work
- add regression coverage for invalid JSON handling

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/profile/update/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment