### PR TITLE
fix(webhooks): validate Telnyx SMS payload

### DIFF
--- a/src/app/api/webhooks/telnyx/sms/route.js
+++ b/src/app/api/webhooks/telnyx/sms/route.js
@@ -120,6 +120,11 @@ export async function POST(request) {
 		}
 
 		const payload = body.data.payload;
+		if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+			console.log('[TELNYX-WEBHOOK] Invalid message payload');
+			return NextResponse.json({ error: 'Invalid message payload' }, { status: 400 });
+		}
+
 		const fromPhone = payload.from?.phone_number;
 		const toPhone = payload.to?.[0]?.phone_number;
 		const messageText = payload.text;

--- a/src/app/api/webhooks/telnyx/sms/route.test.js
+++ b/src/app/api/webhooks/telnyx/sms/route.test.js
@@ -43,4 +43,20 @@ describe('Telnyx SMS webhook', () => {
 		expect(mocks.createServiceRoleClient).not.toHaveBeenCalled();
 		expect(mocks.createSMSWebhookEmailService).not.toHaveBeenCalled();
 	});
+
+	it('returns 400 for message events with a malformed payload object', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(webhookRequest(JSON.stringify({
+			data: {
+				event_type: 'message.received',
+				payload: null
+			}
+		})));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid message payload');
+		expect(mocks.createServiceRoleClient).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return a controlled 400 response when a Telnyx message.received event has a malformed payload
- avoid reading phone/text fields from null or array payloads
- add regression coverage that malformed payloads stop before OTP verification work

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/webhooks/telnyx/sms/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment