### PR TITLE
fix(webhooks): validate Telnyx SMS text

### DIFF
--- a/src/app/api/webhooks/telnyx/sms/route.js
+++ b/src/app/api/webhooks/telnyx/sms/route.js
@@ -130,6 +130,11 @@ export async function POST(request) {
 			return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
 		}
 
+		if (typeof messageText !== 'string') {
+			console.log('[TELNYX-WEBHOOK] Invalid message text type');
+			return NextResponse.json({ error: 'Invalid message text' }, { status: 400 });
+		}
+
 		// Extract OTP code from message text (assuming it's just the code)
 		const otpCode = messageText.trim();
 		

--- a/src/app/api/webhooks/telnyx/sms/route.test.js
+++ b/src/app/api/webhooks/telnyx/sms/route.test.js
@@ -43,4 +43,25 @@ describe('Telnyx SMS webhook', () => {
 		expect(mocks.createServiceRoleClient).not.toHaveBeenCalled();
 		expect(mocks.createSMSWebhookEmailService).not.toHaveBeenCalled();
 	});
+
+	it('returns 400 for message events with non-string SMS text', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(webhookRequest(JSON.stringify({
+			data: {
+				event_type: 'message.received',
+				payload: {
+					id: 'message-1',
+					from: { phone_number: '+15551234567' },
+					to: [{ phone_number: '+15557654321' }],
+					text: 123456
+				}
+			}
+		})));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid message text');
+		expect(mocks.createServiceRoleClient).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- return 400 when Telnyx message.received payloads contain non-string SMS text
- avoid calling trim() on malformed provider payload fields
- add regression coverage that invalid text stops before OTP verification work

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/webhooks/telnyx/sms/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment