### PR TITLE
fix(settings): require integer retention days

### DIFF
--- a/src/app/api/settings/disappearing-messages/route.js
+++ b/src/app/api/settings/disappearing-messages/route.js
@@ -78,7 +78,11 @@ export async function PUT(request) {
 		const { default_message_retention_days } = await request.json();
 
 		// Validate input
-		if (typeof default_message_retention_days !== 'number' || default_message_retention_days < 0) {
+		if (
+			typeof default_message_retention_days !== 'number' ||
+			!Number.isInteger(default_message_retention_days) ||
+			default_message_retention_days < 0
+		) {
 			return NextResponse.json({ error: 'Invalid retention days value' }, { status: 400 });
 		}
 

--- a/src/app/api/settings/disappearing-messages/route.test.js
+++ b/src/app/api/settings/disappearing-messages/route.test.js
@@ -130,4 +130,16 @@ describe('settings disappearing messages authentication', () => {
 		expect(mocks.authGetUser).toHaveBeenCalledWith('valid-token');
 		expect(mocks.updateEq).toHaveBeenCalledWith('auth_user_id', 'auth-user-id');
 	});
+
+	it('rejects fractional retention day values before updating settings', async () => {
+		const { PUT } = await import('./route.js');
+
+		const response = await PUT(request('PUT', { default_message_retention_days: 1.5 }));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid retention days value');
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.updateEq).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject fractional disappearing-message retention values
- keep retention settings limited to non-negative whole days
- add regression coverage that prevents decimal values from reaching the update query

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/settings/disappearing-messages/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment