### PR TITLE
fix(conversations): require integer disappearing seconds

### DIFF
--- a/src/app/api/conversations/[id]/disappearing-messages/route.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/route.js
@@ -188,8 +188,8 @@ export async function PUT(request, { params } = {}) {
     const { disappear_seconds, start_on } = body;
 
     // Validate input
-    if (typeof disappear_seconds !== 'number' || disappear_seconds < 0) {
-      return NextResponse.json({ error: 'disappear_seconds must be a non-negative number' }, { status: 400 });
+    if (typeof disappear_seconds !== 'number' || !Number.isInteger(disappear_seconds) || disappear_seconds < 0) {
+      return NextResponse.json({ error: 'disappear_seconds must be a non-negative integer' }, { status: 400 });
     }
 
     if (start_on && !['delivered', 'read'].includes(start_on)) {

--- a/src/app/api/conversations/[id]/disappearing-messages/route.test.js
+++ b/src/app/api/conversations/[id]/disappearing-messages/route.test.js
@@ -146,4 +146,23 @@ describe('/api/conversations/[id]/disappearing-messages', () => {
 		expect(mocks.participantEq).not.toHaveBeenCalled();
 		expect(mocks.updateEq).not.toHaveBeenCalled();
 	});
+
+	it('rejects fractional disappearing seconds before participant lookup', async () => {
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			if (table === 'conversation_participants') throw new Error('Participant query should not run');
+			throw new Error(`Unexpected table: ${table}`);
+		});
+
+		const { PUT } = await import('./route.js');
+		const response = await PUT(makeRequest({ disappear_seconds: 1.5 }), {
+			params: Promise.resolve({ id: 'conversation-1' })
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('disappear_seconds must be a non-negative integer');
+		expect(mocks.participantEq).not.toHaveBeenCalled();
+		expect(mocks.updateEq).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject fractional per-conversation disappearing-message timers
- keep `disappear_seconds` constrained to non-negative integer seconds
- add regression coverage that blocks decimal values before participant/update queries

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/conversations/[id]/disappearing-messages/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment