### PR TITLE
fix(auth): validate verify sms profile strings

### DIFF
--- a/src/app/api/auth/verify-sms/route.js
+++ b/src/app/api/auth/verify-sms/route.js
@@ -101,6 +101,14 @@ export async function POST(request, { params } = {}) {
 			}
 		}
 
+		if (username !== null && username !== undefined && typeof username !== 'string') {
+			return NextResponse.json({ error: 'Username must be a string' }, { status: 400 });
+		}
+
+		if (displayName !== null && displayName !== undefined && typeof displayName !== 'string') {
+			return NextResponse.json({ error: 'Display name must be a string' }, { status: 400 });
+		}
+
 		// Validate phone number format for all requests
 		if (!isValidPhoneNumber(phoneNumber)) {
 			logger.error( 'Invalid phone number format', { phoneNumber });

--- a/src/app/api/auth/verify-sms/route.test.js
+++ b/src/app/api/auth/verify-sms/route.test.js
@@ -90,6 +90,21 @@ describe('verify-sms session phone binding', () => {
 		expect(mocks.getUser).not.toHaveBeenCalled();
 	});
 
+	it('rejects non-string usernames before session validation', async () => {
+		const { POST } = await import('./route.js');
+		const res = await POST(sessionRequest({
+			useSession: true,
+			phoneNumber: '+15559999999',
+			username: 123456
+		}));
+		const body = await res.json();
+
+		expect(res.status).toBe(400);
+		expect(body.error).toBe('Username must be a string');
+		expect(mocks.serverClient).not.toHaveBeenCalled();
+		expect(mocks.getUser).not.toHaveBeenCalled();
+	});
+
 	it('rejects anonymous / phoneless sessions', async () => {
 		mocks.getUser.mockResolvedValue({
 			data: { user: { id: 'anon', phone: null } },


### PR DESCRIPTION
## Summary
- reject non-string username and displayName values in verify-sms before DB/session work
- keep signup profile fields constrained to text payloads
- add regression coverage for numeric usernames in the session completion flow

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/verify-sms/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment