### PR TITLE
fix(auth): validate anonymous display names

### DIFF
--- a/src/app/api/auth/register-anon/route.js
+++ b/src/app/api/auth/register-anon/route.js
@@ -72,6 +72,9 @@ export async function POST(request) {
 		if (!publicKey || typeof publicKey !== 'string') {
 			return NextResponse.json({ error: 'Public key is required' }, { status: 400 });
 		}
+		if (displayName !== undefined && displayName !== null && typeof displayName !== 'string') {
+			return NextResponse.json({ error: 'Display name must be a string' }, { status: 400 });
+		}
 
 		// --- Validate anonymous Bearer session ---
 		const authHeader = request.headers.get('authorization');

--- a/src/app/api/auth/register-anon/route.test.js
+++ b/src/app/api/auth/register-anon/route.test.js
@@ -36,6 +36,14 @@ function registerRequest(authorization) {
 	});
 }
 
+function registerRequestWithBody(body, authorization = 'Bearer access-token-123') {
+	return new Request('https://example.com/api/auth/register-anon', {
+		method: 'POST',
+		headers: { authorization },
+		body: JSON.stringify(body)
+	});
+}
+
 describe('register-anon bearer authentication', () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -66,6 +74,24 @@ describe('register-anon bearer authentication', () => {
 
 		expect(response.status).toBe(401);
 		expect(body.error).toBe('Missing authorization header');
+		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
+		expect(mocks.serverAuthGetUser).not.toHaveBeenCalled();
+		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();
+	});
+
+	it('rejects non-string display names before session validation', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(registerRequestWithBody({
+			inviteToken: 'qci1.payload.signature',
+			username: 'anon-user',
+			displayName: ['Alice'],
+			publicKey: 'ml-kem-public-key'
+		}));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Display name must be a string');
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.serverAuthGetUser).not.toHaveBeenCalled();
 		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- reject non-string displayName values in anonymous invite registration
- prevent malformed optional display names from reaching auth, invite verification, or insert work
- add regression coverage for array displayName payloads

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/register-anon/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment