### PR TITLE
fix(crypto): validate public key batch ids

### DIFF
--- a/src/app/api/crypto/public-keys/route.js
+++ b/src/app/api/crypto/public-keys/route.js
@@ -163,11 +163,16 @@ export async function POST(request) {
 			return NextResponse.json({ error: 'Missing or invalid user_ids array' }, { status: 400 });
 		}
 
+		const normalizedUserIds = user_ids.map((userId) => typeof userId === 'string' ? userId.trim() : '');
+		if (normalizedUserIds.some((userId) => !userId)) {
+			return NextResponse.json({ error: 'user_ids must contain non-empty strings' }, { status: 400 });
+		}
+
 		/** @type {Record<string, string|null>} */
 		const publicKeys = {};
 
 		// Process each user ID
-		for (const userId of user_ids) {
+		for (const userId of normalizedUserIds) {
 			try {
 				// Get the user's auth_user_id from the internal user ID
 				const { data: userData, error: userError } = await getServiceRoleClient()

--- a/src/app/api/crypto/public-keys/route.test.js
+++ b/src/app/api/crypto/public-keys/route.test.js
@@ -82,4 +82,25 @@ describe('public key cookie authentication', () => {
 		expect(body).toEqual({ public_key: 'public-key', user_id: 'target-user-id' });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
 	});
+
+	it('rejects blank batch user ids before public key lookup', async () => {
+		const { POST } = await import('./route.js');
+		const response = await POST(
+			new Request('https://qrypt.chat/api/crypto/public-keys', {
+				method: 'POST',
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')}`,
+					'content-type': 'application/json'
+				},
+				body: JSON.stringify({
+					user_ids: ['target-user-id', '   ']
+				})
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'user_ids must contain non-empty strings' });
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject blank or non-string user IDs in batch public-key lookup payloads
- trim valid batch IDs before lookup so responses use normalized keys
- add regression coverage that blocks invalid batch IDs before key RPC work

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/crypto/public-keys/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment