### PR TITLE
fix(crypto): validate public key upserts

### DIFF
--- a/src/app/api/crypto/public-keys/route.js
+++ b/src/app/api/crypto/public-keys/route.js
@@ -224,16 +224,20 @@ export async function PUT(request) {
 
 		const { public_key, key_type = 'ML-KEM-1024' } = await request.json();
 		
-		if (!public_key) {
+		if (!public_key || typeof public_key !== 'string' || !public_key.trim()) {
 			return NextResponse.json({ error: 'Missing public_key' }, { status: 400 });
+		}
+
+		if (typeof key_type !== 'string' || !key_type.trim()) {
+			return NextResponse.json({ error: 'Invalid key_type' }, { status: 400 });
 		}
 
 		// Sync public key to database using the upsert function
 		const { data: result, error } = await getServiceRoleClient()
 			.rpc('upsert_user_public_key', {
 				target_user_id: user.auth_user_id, // Use auth_user_id for the function
-				public_key_param: public_key,
-				key_type_param: key_type
+				public_key_param: public_key.trim(),
+				key_type_param: key_type.trim()
 			});
 
 		if (error) {

--- a/src/app/api/crypto/public-keys/route.test.js
+++ b/src/app/api/crypto/public-keys/route.test.js
@@ -82,4 +82,25 @@ describe('public key cookie authentication', () => {
 		expect(body).toEqual({ public_key: 'public-key', user_id: 'target-user-id' });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
 	});
+
+	it('rejects non-string public keys before upsert RPC work', async () => {
+		const { PUT } = await import('./route.js');
+		const response = await PUT(
+			new Request('https://qrypt.chat/api/crypto/public-keys', {
+				method: 'PUT',
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${cookieValue('access-token')}`,
+					'content-type': 'application/json'
+				},
+				body: JSON.stringify({
+					public_key: { key: 'ml-kem-public-key' }
+				})
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toEqual({ error: 'Missing public_key' });
+		expect(mocks.rpc).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject non-string or blank public_key payloads before public-key upsert RPC work
- reject malformed key_type overrides and trim valid key values before storage
- add regression coverage for object public_key payloads

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/crypto/public-keys/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment