### PR TITLE
fix(auth): validate verify sms phone strings

### DIFF
--- a/src/app/api/auth/verify-sms/route.js
+++ b/src/app/api/auth/verify-sms/route.js
@@ -60,6 +60,10 @@ export async function POST(request, { params } = {}) {
 			return NextResponse.json({ error: 'Invalid request format' }, { status: 400 });
 		}
 
+		if (phoneNumber !== null && phoneNumber !== undefined && typeof phoneNumber !== 'string') {
+			return NextResponse.json({ error: 'Phone number must be a string' }, { status: 400 });
+		}
+
 		logger.info('SMS verification request received', {
 			phoneNumber: phoneNumber ? `${phoneNumber.substring(0, 3)}***${phoneNumber.substring(phoneNumber.length - 2)}` : null,
 			hasCode: !!verificationCode,

--- a/src/app/api/auth/verify-sms/route.test.js
+++ b/src/app/api/auth/verify-sms/route.test.js
@@ -90,6 +90,21 @@ describe('verify-sms session phone binding', () => {
 		expect(mocks.getUser).not.toHaveBeenCalled();
 	});
 
+	it('rejects non-string phone numbers before session validation', async () => {
+		const { POST } = await import('./route.js');
+		const res = await POST(sessionRequest({
+			useSession: true,
+			phoneNumber: 15559999999,
+			username: 'alice'
+		}));
+		const body = await res.json();
+
+		expect(res.status).toBe(400);
+		expect(body.error).toBe('Phone number must be a string');
+		expect(mocks.serverClient).not.toHaveBeenCalled();
+		expect(mocks.getUser).not.toHaveBeenCalled();
+	});
+
 	it('rejects anonymous / phoneless sessions', async () => {
 		mocks.getUser.mockResolvedValue({
 			data: { user: { id: 'anon', phone: null } },


### PR DESCRIPTION
## Summary
- reject non-string phoneNumber values before verify-sms logging or session validation
- prevent malformed phone payloads from reaching substring masking or auth work
- add regression coverage for numeric phoneNumber payloads

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/verify-sms/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment