### PR TITLE
fix(auth): reject blank anonymous public keys

### DIFF
--- a/src/app/api/auth/register-anon/route.js
+++ b/src/app/api/auth/register-anon/route.js
@@ -72,6 +72,10 @@ export async function POST(request) {
 		if (!publicKey || typeof publicKey !== 'string') {
 			return NextResponse.json({ error: 'Public key is required' }, { status: 400 });
 		}
+		const normalizedPublicKey = publicKey.trim();
+		if (!normalizedPublicKey) {
+			return NextResponse.json({ error: 'Public key is required' }, { status: 400 });
+		}
 
 		// --- Validate anonymous Bearer session ---
 		const authHeader = request.headers.get('authorization');
@@ -179,7 +183,7 @@ export async function POST(request) {
 			.insert({
 				user_id: authUser.id,
 				key_type: 'ML-KEM-1024',
-				public_key: publicKey
+				public_key: normalizedPublicKey
 			});
 
 		if (keyError) {

--- a/src/app/api/auth/register-anon/route.test.js
+++ b/src/app/api/auth/register-anon/route.test.js
@@ -24,14 +24,15 @@ vi.mock('@/lib/invites/verify.js', () => ({
 	InviteVerificationError: class InviteVerificationError extends Error {}
 }));
 
-function registerRequest(authorization) {
+function registerRequest(authorization, overrides = {}) {
 	return new Request('https://example.com/api/auth/register-anon', {
 		method: 'POST',
 		headers: authorization ? { authorization } : {},
 		body: JSON.stringify({
 			inviteToken: 'qci1.payload.signature',
 			username: 'anon-user',
-			publicKey: 'ml-kem-public-key'
+			publicKey: 'ml-kem-public-key',
+			...overrides
 		})
 	});
 }
@@ -66,6 +67,21 @@ describe('register-anon bearer authentication', () => {
 
 		expect(response.status).toBe(401);
 		expect(body.error).toBe('Missing authorization header');
+		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
+		expect(mocks.serverAuthGetUser).not.toHaveBeenCalled();
+		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank public keys before validating the session', async () => {
+		const { POST } = await import('./route.js');
+
+		const response = await POST(registerRequest('Bearer access-token-123', {
+			publicKey: '   '
+		}));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Public key is required');
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.serverAuthGetUser).not.toHaveBeenCalled();
 		expect(mocks.verifyInviteToken).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- reject whitespace-only publicKey payloads during anonymous invite registration
- trim valid public keys before storing them
- add regression coverage that stops blank keys before session or invite validation

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/auth/register-anon/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment