### PR TITLE
fix(messages): reject blank encrypted payloads

### DIFF
--- a/src/app/api/messages/send/route.js
+++ b/src/app/api/messages/send/route.js
@@ -41,6 +41,10 @@ export const POST = withAuth(async ({ request, locals }) => {
 			return NextResponse.json({ error: 'encryptedContents values must be encrypted content strings' }, { status: 400 });
 		}
 
+		if (Object.values(encryptedContents).some((content) => !content.trim())) {
+			return NextResponse.json({ error: 'encryptedContents values must not be blank' }, { status: 400 });
+		}
+
 		if (metadata !== undefined && (typeof metadata !== 'object' || Array.isArray(metadata) || metadata === null)) {
 			return NextResponse.json({ error: 'metadata must be a JSON object' }, { status: 400 });
 		}

--- a/src/app/api/messages/send/route.test.js
+++ b/src/app/api/messages/send/route.test.js
@@ -81,6 +81,25 @@ describe('POST /api/messages/send validation', () => {
 		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
 	});
 
+	it('rejects blank encrypted content strings before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				conversationId: 'conversation-1',
+				encryptedContents: {
+					'user-1': '   '
+				}
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('encryptedContents values must not be blank');
+		expect(mocks.mockSupabase.from).not.toHaveBeenCalled();
+	});
+
 	it('rejects non-object metadata before database work', async () => {
 		const { POST } = await import('./route.js');
 		const request = {


### PR DESCRIPTION
## Summary
- reject blank encryptedContents values before send-message database work
- prevent whitespace-only encrypted payloads from being base64-encoded into recipient copies
- add regression coverage for blank encrypted content strings

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/messages/send/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment