### PR TITLE
fix(files): reject empty upload metadata

### DIFF
--- a/src/app/api/files/upload-complete/route.js
+++ b/src/app/api/files/upload-complete/route.js
@@ -65,6 +65,10 @@ export async function POST(request, { params } = {}) {
 			console.error('UPLOAD-COMPLETE: Invalid encrypted metadata');
 			return NextResponse.json({ error: 'Invalid encrypted metadata' }, { status: 400 });
 		}
+		if (Object.keys(encryptedMetadata).length === 0) {
+			console.error('UPLOAD-COMPLETE: No encrypted metadata found');
+			return NextResponse.json({ error: 'Invalid encrypted metadata' }, { status: 400 });
+		}
 
 		// Get the internal user ID from the users table using auth_user_id
 		const { data: internalUser, error: userError } = await supabase

--- a/src/app/api/files/upload-complete/route.test.js
+++ b/src/app/api/files/upload-complete/route.test.js
@@ -108,4 +108,27 @@ describe('POST /api/files/upload-complete validation', () => {
 		expect(mocks.from).not.toHaveBeenCalled();
 		expect(mocks.broadcastToRoom).not.toHaveBeenCalled();
 	});
+
+	it('rejects empty encrypted metadata before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				storagePath: 'auth-user-id/conversation-1/file-1',
+				fileId: 'file-1',
+				metadata: {
+					messageId: 'message-1',
+					conversationId: 'conversation-1',
+					encryptedMetadata: {}
+				}
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid encrypted metadata');
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.broadcastToRoom).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject empty encryptedMetadata maps during upload completion
- prevent file records from being saved without any recipient metadata copy
- add regression coverage for empty encrypted metadata payloads

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/files/upload-complete/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment