### PR TITLE
chore: untrack Claude Code local-only files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(identify:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 supabase/.temp/
 .next/
+
+# Claude Code: local-only, machine-specific (keep shared config committed)
+**/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
`.claude/settings.local.json` holds machine-specific Claude Code permission allowlists and was committed by accident. This untracks it (the file stays on disk locally) and adds a targeted `.gitignore` rule.

Shared Claude config — `settings.json`, `commands/`, `skills/`, `agents/`, `CLAUDE.md` — is intentionally **left tracked**, so this is deliberately narrower than ignoring all of `.claude/`.

Note: a `.gitignore` entry alone does not help once a file is already tracked, which is why the `git rm --cached` is required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)