### PR TITLE
fix(files): validate upload metadata values

### DIFF
--- a/src/app/api/files/upload-url/route.js
+++ b/src/app/api/files/upload-url/route.js
@@ -59,6 +59,10 @@ export async function POST(request, { params } = {}) {
 			console.error('UPLOAD-URL: No encrypted metadata found');
 			return NextResponse.json({ error: 'Invalid encrypted metadata' }, { status: 400 });
 		}
+		if (Object.values(encryptedMetadata).some((value) => typeof value !== 'string' || !value.trim())) {
+			console.error('UPLOAD-URL: Invalid encrypted metadata values');
+			return NextResponse.json({ error: 'Invalid encrypted metadata' }, { status: 400 });
+		}
 
 		// Get the internal user ID from the users table using auth_user_id
 		const { data: internalUser, error: userError } = await supabase

--- a/src/app/api/files/upload-url/route.test.js
+++ b/src/app/api/files/upload-url/route.test.js
@@ -69,4 +69,44 @@ describe('POST /api/files/upload-url validation', () => {
 		expect(body.error).toBe('Invalid encrypted metadata');
 		expect(mocks.from).not.toHaveBeenCalled();
 	});
+
+	it('rejects non-string encrypted metadata values before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				conversationId: 'conversation-1',
+				messageId: 'message-1',
+				encryptedMetadata: {
+					'user-1': { ciphertext: 'abc' }
+				}
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid encrypted metadata');
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
+
+	it('rejects blank encrypted metadata values before database work', async () => {
+		const { POST } = await import('./route.js');
+		const request = {
+			json: vi.fn().mockResolvedValue({
+				conversationId: 'conversation-1',
+				messageId: 'message-1',
+				encryptedMetadata: {
+					'user-1': '   '
+				}
+			})
+		};
+
+		const response = await POST(request);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid encrypted metadata');
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- reject non-string or blank encryptedMetadata values before upload-url database work
- prevent malformed recipient metadata maps from reaching profile/conversation lookups
- add regression coverage for object and whitespace-only metadata values

## Test
- node node_modules\vitest\vitest.mjs run --config %TEMP%\qryptchat-vitest-minimal.config.mjs "src/app/api/files/upload-url/route.test.js"
- git diff --check

## uGig billing
- Expected invoice: 0.50 USD if accepted/merged
- Counted as revenue now: no, pending review/payment