### PR TITLE
fix(files): authorize metadata with internal user ids

### DIFF
--- a/src/app/api/files/[fileId]/route.js
+++ b/src/app/api/files/[fileId]/route.js
@@ -173,12 +173,23 @@ export async function HEAD(request, { params } = {}) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const userId = user.id;
 		const { fileId } = await resolveRouteParams(params);
 		const normalizedFileId = normalizeFileId(fileId);
 		if (!normalizedFileId) {
 			return missingFileIdResponse();
 		}
+
+		const { data: internalUser, error: userError } = await supabase
+			.from('users')
+			.select('id')
+			.eq('auth_user_id', user.id)
+			.single();
+
+		if (userError || !internalUser) {
+			return NextResponse.json({ error: 'User profile not found' }, { status: 404 });
+		}
+
+		const userId = internalUser.id;
 
 		// Get file metadata from database
 		const { data: fileData, error: fileError } = await supabase
@@ -189,13 +200,15 @@ export async function HEAD(request, { params } = {}) {
 				created_at,
 				messages!inner(
 					conversation_id,
-					conversation_participants!inner(
-						user_id
+					conversations!inner(
+						conversation_participants!inner(
+							user_id
+						)
 					)
 				)
 			`)
 			.eq('id', normalizedFileId)
-			.eq('messages.conversation_participants.user_id', userId)
+			.eq('messages.conversations.conversation_participants.user_id', userId)
 			.single();
 
 		if (fileError || !fileData) {
@@ -231,12 +244,24 @@ export async function POST(request, { params } = {}) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const userId = user.id;
 		const { fileId } = await resolveRouteParams(params);
 		const normalizedFileId = normalizeFileId(fileId);
 		if (!normalizedFileId) {
 			return missingFileIdResponse();
 		}
+
+		const authUserId = user.id;
+		const { data: internalUser, error: userError } = await supabase
+			.from('users')
+			.select('id')
+			.eq('auth_user_id', authUserId)
+			.single();
+
+		if (userError || !internalUser) {
+			return NextResponse.json({ error: 'User profile not found' }, { status: 404 });
+		}
+
+		const userId = internalUser.id;
 
 		console.log(`📁 [FILE-INFO] Info request from user: ${userId} for file: ${fileId}`);
 
@@ -252,13 +277,15 @@ export async function POST(request, { params } = {}) {
 				messages!inner(
 					id,
 					conversation_id,
-					conversation_participants!inner(
-						user_id
+					conversations!inner(
+						conversation_participants!inner(
+							user_id
+						)
 					)
 				)
 			`)
 			.eq('id', normalizedFileId)
-			.eq('messages.conversation_participants.user_id', userId)
+			.eq('messages.conversations.conversation_participants.user_id', userId)
 			.single();
 
 		if (fileError || !fileData) {
@@ -274,7 +301,7 @@ export async function POST(request, { params } = {}) {
 			encryptedMetadata: fileData.encrypted_metadata, // Client will decrypt
 			createdAt: fileData.created_at,
 			createdBy: fileData.created_by,
-			isOwner: fileData.created_by === userId
+			isOwner: fileData.created_by === authUserId || fileData.created_by === userId
 		});
 
 	} catch (err) {

--- a/src/app/api/files/[fileId]/route.test.js
+++ b/src/app/api/files/[fileId]/route.test.js
@@ -42,16 +42,29 @@ function createFileQuery() {
 	return query;
 }
 
+function createUserQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: vi.fn(() => query),
+		single: vi.fn().mockResolvedValue({
+			data: { id: 'user-1' },
+			error: null
+		})
+	};
+	return query;
+}
+
 describe('/api/files/[fileId]', () => {
 	beforeEach(() => {
 		vi.resetModules();
 		vi.clearAllMocks();
 
 		mocks.authGetUser.mockResolvedValue({
-			data: { user: { id: 'user-1' } },
+			data: { user: { id: 'auth-user-1' } },
 			error: null
 		});
 		mocks.from.mockImplementation((table) => {
+			if (table === 'users') return createUserQuery();
 			if (table === 'encrypted_files') return createFileQuery();
 			throw new Error(`Unexpected table: ${table}`);
 		});
@@ -79,6 +92,10 @@ describe('/api/files/[fileId]', () => {
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Content-Type')).toBe('application/octet-stream');
 		expect(mocks.eq).toHaveBeenCalledWith('id', 'file-1');
+		expect(mocks.eq).toHaveBeenCalledWith(
+			'messages.conversations.conversation_participants.user_id',
+			'user-1'
+		);
 	});
 
 	it('resolves async route params for POST metadata requests', async () => {
@@ -92,5 +109,9 @@ describe('/api/files/[fileId]', () => {
 		expect(body.id).toBe('file-1');
 		expect(body.conversationId).toBe('conversation-1');
 		expect(mocks.eq).toHaveBeenCalledWith('id', 'file-1');
+		expect(mocks.eq).toHaveBeenCalledWith(
+			'messages.conversations.conversation_participants.user_id',
+			'user-1'
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- resolve the internal profile ID before authorizing `HEAD` and `POST /api/files/:fileId`
- traverse the valid `messages -> conversations -> conversation_participants` relationship used by the working download handler
- preserve ownership detection for records written with either auth UUIDs or legacy internal IDs

## Tests

- all file-route tests: 21 passed across 5 files
- ESLint on both changed files
- `git diff --check`

## Local tooling note

The repository's default Vitest config currently fails before collection because locked `@vitejs/plugin-react@6` imports an unexported Vite 7 subpath. The non-JSX file-route tests were run with the same environment, setup file, and aliases without that plugin. The configured Prettier plugin is also not declared locally; no dependency files were changed.

Closes #216