### PR TITLE
fix(conversations): validate chat participant ids

### DIFF
--- a/src/app/api/chat/conversations/route.js
+++ b/src/app/api/chat/conversations/route.js
@@ -113,14 +113,25 @@ export async function POST(request, { params } = {}) {
 			return NextResponse.json({ error: 'participant_ids is required and must be a non-empty array' }, { status: 400 });
 		}
 
+		const normalizedParticipantIds = participant_ids.map((participantId) =>
+			typeof participantId === 'string' ? participantId.trim() : ''
+		);
+
+		if (
+			normalizedParticipantIds.length !== participant_ids.length ||
+			normalizedParticipantIds.some((participantId) => participantId.length === 0)
+		) {
+			return NextResponse.json({ error: 'participant_ids must contain non-empty strings' }, { status: 400 });
+		}
+
 		// Skip participant validation for now due to network issues
 		// TODO: Re-enable participant validation once network connectivity is stable
 		console.log('Skipping participant validation due to network issues');
 		console.log('Participant IDs to add:', participant_ids);
 
 		// For direct messages, check if conversation already exists
-		if (type === 'direct' && participant_ids.length === 1) {
-			const other_user_id = participant_ids[0];
+		if (type === 'direct' && normalizedParticipantIds.length === 1) {
+			const other_user_id = normalizedParticipantIds[0];
 			
 			// Check if conversation already exists between these users
 			const { data: existingConversations } = await supabase
@@ -175,7 +186,7 @@ export async function POST(request, { params } = {}) {
 		const participants = [];
 
 		// Add other participants (validate they exist in users table)
-		for (const participantId of participant_ids) {
+		for (const participantId of normalizedParticipantIds) {
 			participants.push({
 				conversation_id: conversationId,
 				user_id: participantId,
@@ -185,7 +196,7 @@ export async function POST(request, { params } = {}) {
 
 		if (internalUser) {
 			// Add creator as admin if not already in participants
-			if (!participant_ids.includes(internalUser.id)) {
+			if (!normalizedParticipantIds.includes(internalUser.id)) {
 				participants.push({
 					conversation_id: conversationId,
 					user_id: internalUser.id,

--- a/src/app/api/chat/conversations/route.test.js
+++ b/src/app/api/chat/conversations/route.test.js
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	authGetUser: vi.fn(),
+	from: vi.fn()
+}));
+
+vi.mock('@/lib/supabase.js', () => ({
+	createSupabaseServerClient: vi.fn(async () => ({
+		auth: { getUser: mocks.authGetUser },
+		from: mocks.from
+	}))
+}));
+
+function createUsersQuery() {
+	const query = {
+		select: vi.fn(() => query),
+		eq: vi.fn(() => query),
+		maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+	};
+	return query;
+}
+
+describe('POST /api/chat/conversations participant validation', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		mocks.authGetUser.mockResolvedValue({
+			data: { user: { id: 'auth-user-id' } },
+			error: null
+		});
+		mocks.from.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			throw new Error(`Unexpected database table: ${table}`);
+		});
+	});
+
+	it.each([
+		['blank', ['  ']],
+		['non-string', [null]]
+	])('rejects %s participant ids before conversation creation', async (_label, participant_ids) => {
+		const { POST } = await import('./route.js');
+		const response = await POST(new Request('https://qrypt.chat/api/chat/conversations', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ type: 'direct', participant_ids })
+		}));
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('participant_ids must contain non-empty strings');
+		expect(mocks.from).toHaveBeenCalledWith('users');
+		expect(mocks.from).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- trim participant IDs before duplicate checks and inserts
- reject null, non-string, and blank participant IDs with a 400 response
- add focused regression coverage for malformed participant arrays

## Verification
- node node_modules\\vitest\\vitest.mjs run --config %TEMP%\\qryptchat-vitest-minimal.config.mjs src/app/api/chat/conversations/route.test.js
- git diff --check

This is a focused hardening fix for the accepted uGig QryptChat testing gig.