### PR TITLE
fix(auth): preserve padded cookie values across auth routes

### DIFF
--- a/src/app/api/auth/backup-pin/route.js
+++ b/src/app/api/auth/backup-pin/route.js
@@ -49,7 +49,9 @@ async function authenticateUser(request) {
 
 		const cookies = Object.fromEntries(
 			cookieHeader.split(/;\s*/).map(cookie => {
-				const [name, value] = cookie.split('=');
+				const separator = cookie.indexOf('=');
+				const name = separator === -1 ? cookie : cookie.slice(0, separator);
+				const value = separator === -1 ? '' : cookie.slice(separator + 1);
 				return [name, decodeURIComponent(value)];
 			})
 		);

--- a/src/app/api/auth/backup-pin/route.test.js
+++ b/src/app/api/auth/backup-pin/route.test.js
@@ -23,6 +23,10 @@ function cookieValue(token) {
 	return `base64-${Buffer.from(JSON.stringify({ access_token: token })).toString('base64')}`;
 }
 
+function paddedCookieValue() {
+	return 'base64-eyJhY2Nlc3NfdG9rZW4iOiJhYmMiLCJwYWRkaW5nIjoieCJ9==';
+}
+
 function createUsersQuery() {
 	const query = {
 		select: vi.fn(() => query),
@@ -68,6 +72,20 @@ describe('backup PIN cookie authentication', () => {
 		expect(response.status).toBe(200);
 		expect(body).toEqual({ hasPin: true });
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+
+	it('preserves equals padding in base64 auth cookies', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/backup-pin', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${paddedCookieValue()}`
+				}
+			})
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.authGetUser).toHaveBeenCalledWith('abc');
 	});
 
 	it('normalizes bearer scheme casing and extra spaces', async () => {

--- a/src/app/api/auth/key-backup/route.js
+++ b/src/app/api/auth/key-backup/route.js
@@ -51,7 +51,9 @@ async function authenticateUser(request) {
 
 		const cookies = Object.fromEntries(
 			cookieHeader.split(/;\s*/).map(cookie => {
-				const [name, value] = cookie.split('=');
+				const separator = cookie.indexOf('=');
+				const name = separator === -1 ? cookie : cookie.slice(0, separator);
+				const value = separator === -1 ? '' : cookie.slice(separator + 1);
 				return [name, decodeURIComponent(value)];
 			})
 		);

--- a/src/app/api/auth/key-backup/route.test.js
+++ b/src/app/api/auth/key-backup/route.test.js
@@ -23,6 +23,10 @@ function cookieValue(token) {
 	return `base64-${Buffer.from(JSON.stringify({ access_token: token })).toString('base64')}`;
 }
 
+function paddedCookieValue() {
+	return 'base64-eyJhY2Nlc3NfdG9rZW4iOiJhYmMiLCJwYWRkaW5nIjoieCJ9==';
+}
+
 function createBackupQuery() {
 	const query = {
 		select: vi.fn(() => query),
@@ -96,6 +100,20 @@ describe('key backup cookie authentication', () => {
 			}
 		});
 		expect(mocks.authGetUser).toHaveBeenCalledWith('access-token');
+	});
+
+	it('preserves equals padding in base64 auth cookies', async () => {
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/auth/key-backup', {
+				headers: {
+					cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${paddedCookieValue()}`
+				}
+			})
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.authGetUser).toHaveBeenCalledWith('abc');
 	});
 
 	it('normalizes bearer scheme casing and extra spaces', async () => {

--- a/src/app/api/chat/conversations/[id]/participants/route.js
+++ b/src/app/api/chat/conversations/[id]/participants/route.js
@@ -37,7 +37,9 @@ async function authenticateUser(request) {
 		// Parse cookies to find auth token
 		const cookies = Object.fromEntries(
 			cookieHeader.split(/;\s*/).map(cookie => {
-				const [name, value] = cookie.split('=');
+				const separator = cookie.indexOf('=');
+				const name = separator === -1 ? cookie : cookie.slice(0, separator);
+				const value = separator === -1 ? '' : cookie.slice(separator + 1);
 				return [name, decodeURIComponent(value)];
 			})
 		);

--- a/src/app/api/chat/conversations/[id]/participants/route.test.js
+++ b/src/app/api/chat/conversations/[id]/participants/route.test.js
@@ -21,6 +21,10 @@ vi.mock('@/lib/supabase/service-role.js', () => ({
 	}))
 }));
 
+function paddedCookieValue() {
+	return 'base64-eyJhY2Nlc3NfdG9rZW4iOiJhYmMiLCJwYWRkaW5nIjoieCJ9==';
+}
+
 function createUsersQuery() {
 	const query = {
 		select: vi.fn(() => query),
@@ -108,6 +112,27 @@ describe('GET /api/chat/conversations/[id]/participants', () => {
 		expect(body.conversation_id).toBe('conversation-1');
 		expect(body.participants).toHaveLength(1);
 		expect(mocks.participantEq).toHaveBeenCalledWith('conversation_id', 'conversation-1');
+	});
+
+	it('preserves equals padding in base64 auth cookies', async () => {
+		mocks.serviceFrom.mockImplementation((table) => {
+			if (table === 'users') return createUsersQuery();
+			if (table === 'conversation_participants') {
+				return createParticipantCheckQuery();
+			}
+			throw new Error(`Unexpected table: ${table}`);
+		});
+
+		const { GET } = await import('./route.js');
+		const response = await GET(
+			new Request('https://qrypt.chat/api/chat/conversations/conversation-1/participants', {
+				headers: { cookie: `sb-xydzwxwsbgmznthiiscl-auth-token=${paddedCookieValue()}` }
+			}),
+			{ params: Promise.resolve({ id: 'conversation-1' }) }
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.authGetUser).toHaveBeenCalledWith('abc');
 	});
 
 	it('rejects missing async route params after authentication', async () => {


### PR DESCRIPTION
Preserve complete auth cookie values after the first separator in key-backup, backup-pin, and conversation participant routes. Padded base64 values can contain '='; splitting on every separator truncated them and caused authentication failures. Adds regression coverage for each endpoint.\n\nTests: 14 passed across 3 Vitest files.