### PR TITLE
fix(auth): preserve padded message cookie values

### DIFF
--- a/src/app/api/chat/messages/[id]/route.js
+++ b/src/app/api/chat/messages/[id]/route.js
@@ -28,7 +28,8 @@ async function authenticateUser(request) {
 			return null;
 		}
 		
-		const token = sessionCookie.split('=')[1];
+		const separatorIndex = sessionCookie.indexOf('=');
+		const token = separatorIndex >= 0 ? sessionCookie.slice(separatorIndex + 1) : '';
 		if (!token) {
 			return null;
 		}

--- a/src/app/api/chat/messages/[id]/route.test.js
+++ b/src/app/api/chat/messages/[id]/route.test.js
@@ -102,6 +102,18 @@ describe('GET /api/chat/messages/[id]', () => {
 		expect(mocks.messageEq).toHaveBeenCalledWith('id', 'message-1');
 	});
 
+	it('preserves padded auth cookie values when verifying the session', async () => {
+		const { GET } = await import('./route.js');
+		await GET(
+			new Request('https://qrypt.chat/api/chat/messages/message-1', {
+				headers: { cookie: 'sb-access-token=valid-token==' }
+			}),
+			{ params: Promise.resolve({ id: 'message-1' }) }
+		);
+
+		expect(mocks.authGetUser).toHaveBeenCalledWith('valid-token==');
+	});
+
 	it('rejects missing async route params before authentication', async () => {
 		const { GET } = await import('./route.js');
 		const response = await GET(new Request('https://qrypt.chat/api/chat/messages/'), {


### PR DESCRIPTION
Preserve the complete sb-access-token cookie value in GET /api/chat/messages/[id]. Splitting on every equals sign truncated padded base64/JWT-like values and could cause authentication failures. Adds a regression test proving the full padded token reaches Supabase auth.\n\nTests: 4 passed in the focused Vitest file.