### PR TITLE
Fix profile validation for falsy non-string fields

### DIFF
--- a/src/app/api/profile/update/route.js
+++ b/src/app/api/profile/update/route.js
@@ -53,11 +53,11 @@ export async function POST(request, { params } = {}) {
 		console.log('Authenticated user from JWT:', { id: user.id, email: user.email, phone: user.phone });
 
 		// Validate input
-		if (bio && typeof bio !== 'string') {
+		if (bio !== undefined && typeof bio !== 'string') {
 			return NextResponse.json({ error: 'Bio must be a string' }, { status: 400 });
 		}
 
-		if (website && typeof website !== 'string') {
+		if (website !== undefined && typeof website !== 'string') {
 			return NextResponse.json({ error: 'Website must be a string' }, { status: 400 });
 		}
 

--- a/src/app/api/profile/update/route.test.js
+++ b/src/app/api/profile/update/route.test.js
@@ -32,11 +32,11 @@ vi.mock('@/lib/supabase.js', () => ({
 	createSupabaseServerClient: mocks.createSupabaseServerClient
 }));
 
-function profileRequest(authorization) {
+function profileRequest(authorization, body = { bio: 'hello' }) {
 	return new Request('https://example.com/api/profile/update', {
 		method: 'POST',
 		headers: authorization ? { authorization } : {},
-		body: JSON.stringify({ bio: 'hello' })
+		body: JSON.stringify(body)
 	});
 }
 
@@ -91,4 +91,24 @@ describe('profile update bearer authentication', () => {
 		expect(mocks.createSupabaseServerClient).not.toHaveBeenCalled();
 		expect(mocks.getUser).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		['bio', null, 'Bio must be a string'],
+		['bio', false, 'Bio must be a string'],
+		['bio', 0, 'Bio must be a string'],
+		['website', null, 'Website must be a string'],
+		['website', false, 'Website must be a string'],
+		['website', 0, 'Website must be a string']
+	])(
+		'rejects falsy non-string %s values instead of throwing',
+		async (field, value, expectedError) => {
+			const { POST } = await import('./route.js');
+
+			const response = await POST(profileRequest('Bearer access-token-123', { [field]: value }));
+			const body = await response.json();
+
+			expect(response.status).toBe(400);
+			expect(body.error).toBe(expectedError);
+		}
+	);
 });


### PR DESCRIPTION
Closes #237

## Summary

- validate every provided `bio` and `website` value instead of only truthy values
- return a 400 response for `null`, `false`, and `0` rather than allowing `.trim()` to throw
- preserve existing behavior for omitted fields and empty strings
- add focused regression coverage for both fields

## Validation

- `vitest run src/app/api/profile/update/route.test.js` (9/9)
- ESLint on both modified files (0 errors)
- `git diff --check`