### PR TITLE
fix(settings): reject malformed retention JSON

### DIFF
--- a/src/app/api/settings/disappearing-messages/route.js
+++ b/src/app/api/settings/disappearing-messages/route.js
@@ -75,7 +75,14 @@ export async function PUT(request) {
 			return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
 		}
 
-		const { default_message_retention_days } = await request.json();
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { default_message_retention_days } = body;
 
 		// Validate input
 		if (

--- a/src/app/api/settings/disappearing-messages/route.test.js
+++ b/src/app/api/settings/disappearing-messages/route.test.js
@@ -142,4 +142,24 @@ describe('settings disappearing messages authentication', () => {
 		expect(mocks.from).not.toHaveBeenCalled();
 		expect(mocks.updateEq).not.toHaveBeenCalled();
 	});
+
+	it('rejects malformed JSON before updating settings', async () => {
+		const { PUT } = await import('./route.js');
+		const malformed = new Request('https://qrypt.chat/api/settings/disappearing-messages', {
+			method: 'PUT',
+			headers: {
+				authorization: 'Bearer valid-token',
+				'content-type': 'application/json'
+			},
+			body: '{"default_message_retention_days":'
+		});
+
+		const response = await PUT(malformed);
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body.error).toBe('Invalid JSON body');
+		expect(mocks.from).not.toHaveBeenCalled();
+		expect(mocks.updateEq).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary

- return a specific 400 response when disappearing-message settings contain malformed JSON
- prevent invalid request bodies from reaching database updates
- add a regression test that reproduces the previous 500 response

## Validation

- focused Vitest: 7 passed
- full Vitest suite: 81 files, 483 tests passed
- focused ESLint: passed
- git diff --check: passed

Closes #241