### PR TITLE
fix(security): revoke anon RPC access, bind RPCs to auth.uid(), version RLS drift

### DIFF
--- a/docs/audits/2026-08-12-qryptchat-web-noir0x63.md
+++ b/docs/audits/2026-08-12-qryptchat-web-noir0x63.md
@@ -1,0 +1,129 @@
+> **Archival note — added by the maintainers, not part of the submission.**
+> This is an unsolicited third-party security report received from an external researcher.
+> It is archived here verbatim for the record. **It has not been accepted as-is** — several
+> severities are inflated and one Critical is misclassified. Read it alongside the
+> maintainer verification in [`2026-08-14-noir0x63-verification.md`](./2026-08-14-noir0x63-verification.md)
+> before acting on anything below.
+
+---
+
+# QryptChat — Web Application Security Assessment
+
+| Field | Value |
+|---|---|
+| **Project** | QryptChat (Independent Research) |
+| **Assessment Date** | 2026-08-12 |
+| **Auditor** | Eduardo Camarillo (Noir0x63) |
+| **Distribution** | Confidential |
+
+---
+
+## About the Researcher
+
+My name is **Eduardo Camarillo**, an independent security researcher known online as [Noir0x63](https://noir0x63.org). My work focuses on applied cryptography, zero-trust architecture, and secure systems engineering. This assessment was conducted independently via static analysis and local blackbox testing. No production systems or user data were accessed. My intent is solely responsible disclosure.
+
+---
+
+## 1. Executive Summary
+
+A comprehensive security audit of **QryptChat** (advertising ML-KEM-1024 E2EE) revealed severe structural authorization flaws. Despite the project's "zero-knowledge" claims, the current codebase allows complete unauthenticated compromise of the platform's user data.
+
+**Overall Risk Rating: CRITICAL**
+
+- **Critical:** The July 2026 security patch (RLS data leak) was never versioned into the repository. New deployments expose all user data (`phone_number`, `backup_pin_hash`, public keys).
+- **Critical:** The `delete_encrypted_data_only` (`SECURITY DEFINER`) function lacks ownership checks, allowing unauthenticated remote destruction of any user's encrypted data (messages, keys, files).
+- **High:** Multiple IDORs and authorization bypasses permit identity spoofing, account takeover, and real-time surveillance of user calls without authentication.
+
+**Key Recommendation:** Re-establish security change control. Patch the RLS policies immediately, revoke `PUBLIC` access to `SECURITY DEFINER` functions, and enforce `auth.uid()` checks in all RPCs.
+
+---
+
+## 2. Findings Summary
+
+| ID | Finding | Severity | Component |
+|---|---|---|---|
+| QRY-01 | Incident 2026-07 RLS patch never versioned | **Critical** | Supabase Migrations |
+| QRY-02 | `delete_encrypted_data_only` unauth data destruction | **Critical** | Supabase RPC |
+| NEW-03 | `/api/users/by-username/` exposes internal `id` | **High** | Web API |
+| QRY-03 | `get_inactive_participants` leaks phone numbers | **High** | Supabase RPC |
+| QRY-04 | IDOR in call history and sessions | **High** | Supabase RPC |
+| QRY-05 | `sync_user_with_auth` spoofing and phone overwrite | **High** | Supabase RPC |
+| QRY-06 | User enumeration via `/api/users/search` | **High** | Web API |
+| NEW-01 | `getSession()` lacks JWT re-validation | **High** | Web API |
+| NEW-02 | IDOR in `get_user_active_calls` | **High** | Supabase RPC |
+| QRY-07 | `is_otp_valid_extended` unconditionally returns true | Medium | Supabase RPC |
+| QRY-08 | `fn_create_message_recipients` lacks validation | Medium | Supabase RPC |
+| QRY-09 | 95 dependency vulnerabilities (52 high) | Medium | Supply chain |
+| NEW-04 | Unsalted SHA-256 for backup PIN | Medium | Web API |
+| NEW-05 | In-memory rate limiter evasions | Medium | Web API |
+| NEW-06 | `GET /api/plugins` filesystem enumeration | Medium | Web API |
+| NEW-09 | `cleanup/legacy-messages` without user scope | Medium | Web API |
+| NEW-07 | Full `phone_number` in production logs | Low | Web API |
+| QRY-10 | Outdated docs & build artifacts in git history | Info | Repository |
+| NEW-08 | Supabase Project-ref hardcoded in HEAD | Info | Repository |
+
+---
+
+## 3. Critical & High Findings Detail
+
+### QRY-01 — RLS Patch Never Versioned (Critical)
+
+The fix for the July 2026 data leak was applied manually to production but never merged into the repository. Current migrations still contain `USING (true)` for `users`, `messages`, and `user_public_keys`.
+
+- **Impact:** Any new deployment allows full extraction of PII (phones, PIN hashes, keys) using the public anon key.
+- **Remediation:** Commit the `lock_down_public_rls_read_access` migration.
+
+### QRY-02 & NEW-03 — Unauthenticated Remote Data Destruction (Critical)
+
+`delete_encrypted_data_only` is a `SECURITY DEFINER` function that accepts an attacker-controlled `authenticated_user_id` without verifying it against `auth.uid()`. By obtaining a victim's internal ID via the unauthenticated `/api/users/by-username/` endpoint (NEW-03), an attacker can use the public anon key to permanently delete the victim's messages, keys, and files.
+
+- **Impact:** Unauthenticated mass destruction of user data. (Fully corroborated in local blackbox testing).
+- **Remediation:** `REVOKE EXECUTE FROM PUBLIC` on the function. Ensure `auth.uid()` matches the requested user ID. Remove internal IDs from public API responses.
+
+### Authorization Bypasses & Surveillance (High)
+
+- **QRY-04 & NEW-02:** `get_user_call_history` and `get_user_active_calls` fail to check `auth.uid()`, allowing attackers to monitor any user's call history and real-time active calls using their internal ID.
+- **QRY-05:** `sync_user_with_auth` allows associating a victim's phone number to an attacker's account or overwriting active accounts due to lack of `auth.uid()` checks.
+- **QRY-03 & QRY-06:** Phone numbers leak via `get_inactive_participants` (no membership check) and `/api/users/search` (allows single-digit enumeration).
+- **NEW-01:** Destructive cleanup routes use `getSession()` (reads local cookie) instead of `getUser()` (revalidates JWT with server), allowing authentication bypass via tampered cookies.
+
+*Note: Medium, Low, and Informational findings are summarized in Section 2. Detailed technical logs and reproduction steps are available upon request.*
+
+---
+
+## 4. Exploitation Chains
+
+- **Chain E (Anonymous Mass Destruction):**
+  Enumerate usernames → Get internal ID via `/api/users/by-username/` → Call `delete_encrypted_data_only` with anon key → Data destroyed.
+
+- **Chain A (PII Compromise on New Deploys):**
+  Use anon key on fresh instance → Extract `users` table due to `USING(true)` RLS → Obtain phone numbers and PIN hashes.
+
+- **Chain F (Real-Time Surveillance):**
+  Get internal ID → Poll `get_user_active_calls` → Monitor target's active calls.
+
+---
+
+## 5. Researcher Contact
+
+To coordinate full report delivery (including detailed evidence and reproduction steps for all 19 findings), clarify technical details, or agree on a remediation window, contact:
+
+| | |
+|---|---|
+| **Website** | [noir0x63.org](https://noir0x63.org) |
+| **Signal** | noir0x.63 |
+
+Public disclosure will be coordinated with the project maintainers following a reasonable remediation window.
+
+---
+
+## Authorship and Certification
+
+**Lead Researcher:**
+Eduardo Camarillo (*Noir0x63*)
+*Independent Security Researcher*
+[noir0x63.org](https://noir0x63.org)
+
+**Signature Date:** August 13, 2026
+
+*Source code verified directly against the `qryptchat-web` repository. All active exploitation was conducted in a strictly isolated local replica. No production systems were accessed or compromised.*

--- a/docs/audits/2026-08-14-noir0x63-verification.md
+++ b/docs/audits/2026-08-14-noir0x63-verification.md
@@ -1,0 +1,217 @@
+# QryptChat — Triage of the Noir0x63 report (verified 2026-08-14)
+
+Companion to [`2026-08-12-qryptchat-web-noir0x63.md`](./2026-08-12-qryptchat-web-noir0x63.md)
+(the original third-party submission). This document is the maintainer verification of it.
+
+Verification method: static review of `qryptchat-web` @ `0375cef`, plus
+**read-only** SQL against the live `qrypt.chat` Supabase project (`xydzwxwsbgmznthiiscl`).
+No destructive RPC was called. No data was modified.
+
+**Bottom line: the report is technically sound.** Its headline critical (QRY-02) is confirmed
+against production. Its other headline critical (QRY-01) is confirmed as *repo drift* but is
+**not** currently exploitable in prod. Several severities are inflated, one finding is dead code,
+and the report **missed** the issue I'd rank second-most serious.
+
+---
+
+## 1. Confirmed against PRODUCTION — fix now
+
+### QRY-02 — anon can execute destructive SECURITY DEFINER RPCs (CRITICAL, real)
+
+Live query result:
+
+| function | SECURITY DEFINER | `anon` EXECUTE | body checks `auth.uid()` |
+|---|---|---|---|
+| `delete_encrypted_data_only(uuid,uuid)` | yes | **yes** | **no** |
+| `get_user_call_history(uuid,int)` | yes | **yes** | **no** |
+| `get_user_active_calls(uuid)` | yes | **yes** | **no** |
+| `get_inactive_participants(uuid)` | yes | **yes** | **no** |
+| `sync_user_with_auth(text,uuid,text,text)` | yes | **yes** | **no** |
+| `fn_create_message_recipients(uuid,jsonb)` | yes | **yes** | **no** |
+| `is_otp_valid_extended(text,text,int)` | yes | **yes** | **no** |
+
+The migrations do `GRANT EXECUTE ... TO authenticated` but **never `REVOKE ... FROM PUBLIC`**, so
+`anon` keeps the default PUBLIC grant. That is the whole bug.
+
+`delete_encrypted_data_only` does have a check — but it is only *self-consistency*:
+
+```sql
+IF target_user_id != authenticated_user_id THEN
+    RAISE EXCEPTION 'Users can only delete their own data';
+END IF;
+```
+
+An attacker passes the **same** victim UUID twice and both checks pass. The report's
+"lacks ownership checks" is accurate in substance: there is no binding to `auth.uid()`.
+
+**Chain E is real.** `/api/users/by-username/[username]` returns the internal `id`
+unauthenticated (service-role read, deliberate — see its own code comment), which supplies the
+UUID. Anon key + that UUID = permanent deletion of a victim's messages, keys, files.
+
+**Scope is wider than reported.** Supabase's own linter on this project returns:
+
+- **48 ×** `anon_security_definer_function_executable`
+- **48 ×** `authenticated_security_definer_function_executable`
+- 30 × `auth_allow_anonymous_sign_ins`
+
+The report named 8. There are 48.
+
+### QRY-09 — dependency vulnerabilities (real, numbers match exactly)
+
+`pnpm audit` on HEAD: **95 vulnerabilities — 4 low, 39 moderate, 52 high**, 685 total deps.
+This matches the report's "95 / 52 high" digit-for-digit, which is good evidence the researcher
+actually ran against this tree rather than boilerplating.
+
+### NEW-04 — unsalted SHA-256 backup PIN (real, and worse than rated)
+
+`src/app/api/auth/backup-pin/route.js:101` — `crypto.subtle.digest('SHA-256', pin)`, no salt,
+no KDF, no iteration. A numeric PIN keyspace falls instantly. See §2 for why this is worse than
+the report says.
+
+---
+
+## 2. The finding the report MISSED (rate this High)
+
+Production RLS on `users`:
+
+```
+users_select_authenticated | SELECT | {authenticated} | USING (true)
+```
+
+The `users` table has columns `phone_number`, `backup_pin_hash`, **and** `salt`. So **any single
+logged-in account** can read the phone number, PIN hash, and salt of **every user on the
+platform**. That is one throwaway signup away.
+
+Combine with NEW-04: dump all `backup_pin_hash` values, and because they are unsalted SHA-256 of
+a short PIN, recover every user's backup PIN with one precomputed table. The report rated the
+weak hash "Medium" in isolation and never connected it to the readable hash column. Chained,
+this is the cleanest path to mass key-backup compromise in the whole set.
+
+**Fix:** restrict `users_select_authenticated` to non-sensitive columns (or move sensitive
+columns to a separate table / column-level grants), and rehash PINs with Argon2id or scrypt
+using the existing per-user `salt`.
+
+---
+
+## 3. Confirmed as repo drift, NOT live exposure
+
+### QRY-01 — RLS patch never versioned (real drift; severity overstated)
+
+The repo's latest migrations still contain, for the `anon`-reachable path:
+
+- `20250926135540_add_unique_user_identifiers.sql` → `CREATE POLICY "Anyone can read user unique identifiers" ON users FOR SELECT USING (true);`
+- `20250824052548_fix_conversations_recursion.sql` → `CREATE POLICY "Users can read all messages" ON messages FOR SELECT USING (true);`
+
+Production, however, **is** patched — the live policies are `users_select_authenticated` and
+`messages_select_participant` (a proper participant check). Neither exists in any migration file.
+Migrations stop at `20260629120000`.
+
+So: the July 2026 fix was applied out-of-band and never versioned. `by-username/route.js` even
+carries a comment asserting *"RLS on `users` is restricted to the `authenticated` role"* — a
+guarantee that exists nowhere in the repo.
+
+**Verdict:** the *drift* is genuine and genuinely dangerous — any fresh deploy, branch DB, or
+`db reset` reintroduces anon-readable `users` and `messages`. But "new deployments expose all
+user data" is a **future/CI risk**, not the current prod state. Rating it Critical alongside a
+live unauthenticated-destruction bug conflates two very different things.
+
+---
+
+## 4. Overstated, downgrade
+
+| ID | Report | Reality | Suggested |
+|---|---|---|---|
+| QRY-06 `/api/users/search` | High, "user enumeration" | Requires auth — uses `getUser()` correctly. Returns only `***-***-1234`. But min query length is 1 char and it does match on `phone_number`, so an authenticated attacker can confirm/enumerate full numbers. | Medium |
+| NEW-06 `GET /api/plugins` | Medium, "filesystem enumeration" | Reads one fixed `community-plugins/` dir and returns curated `plugin.json` metadata. Not arbitrary traversal. | Info |
+| QRY-07 `is_otp_valid_extended` | Medium | Body is `RETURN TRUE;` — accurate. But **zero callers in `src/`**. Dead placeholder code. Still worth dropping (it's anon-executable). | Info |
+| NEW-08 hardcoded project ref | Info | Supabase project ref and anon key are public by design. | Non-issue |
+
+## 5. Confirmed but needs your call on severity
+
+**NEW-01 + NEW-09 (these are one bug, and the pair matters more than either alone).**
+
+Two routes authenticate with `getSession()` instead of `getUser()`:
+
+- `src/app/api/cleanup/legacy-messages/route.js:11`
+- `src/app/api/cleanup/empty-conversations/route.js:11`
+
+`getSession()` reads the cookie without revalidating the JWT against the auth server. 21 route
+files in `src/app/api` correctly use `getUser()`; only 3 use `getSession()`, and the third
+(`auth/session/route.js`) is legitimately a session-reading endpoint. These two are the outliers.
+
+Worse, `legacy-messages` then does this with **no user scoping at all**:
+
+```js
+.from('messages')
+.select('id, encrypted_content')
+.or('encrypted_content.ilike.%FALLBACK%,encrypted_content.ilike.%ML-KEM-768%')
+.limit(1000)
+// ...then deletes every id it found
+```
+
+It deletes up to 1000 matching messages **platform-wide**, not the caller's. It binds `userId`
+from the session only to log it. Whether RLS saves you depends on the client returned by
+`createSupabaseClient()` — worth confirming, but the route should not be written this way
+regardless.
+
+## 6. Not verified
+
+NEW-05 (rate-limiter evasion — `src/lib/server/rate-limiter.js` exists with trusted-proxy
+parsing, not audited), NEW-07 (phone numbers in logs), QRY-10 (git history artifacts).
+
+---
+
+## 7. Suggested immediate remediation
+
+Not applied — this is prod and it isn't my project. Run when ready.
+
+**Step 1 — stop the bleeding (blocks Chain E, keeps the app working since `authenticated` is granted explicitly):**
+
+```sql
+REVOKE EXECUTE ON FUNCTION public.delete_encrypted_data_only(uuid, uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_user_call_history(uuid, integer)   FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_user_active_calls(uuid)            FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_inactive_participants(uuid)        FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.sync_user_with_auth(text, uuid, text, text) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.fn_create_message_recipients(uuid, jsonb)   FROM PUBLIC, anon;
+DROP FUNCTION IF EXISTS public.is_otp_valid_extended(text, text, integer);
+```
+
+Then sweep the other ~42 the linter flags.
+
+**Step 2 — bind ownership to the session, not to the argument:**
+
+```sql
+-- inside delete_encrypted_data_only, replace the self-consistency check
+IF NOT EXISTS (
+    SELECT 1 FROM users
+    WHERE id = target_user_id AND auth_user_id = auth.uid()
+) THEN
+    RAISE EXCEPTION 'Not authorized';
+END IF;
+```
+
+Apply the same pattern to the call-history / active-calls / inactive-participants functions.
+
+**Step 3 — version the drift.** Write the live `users_select_authenticated` and
+`messages_select_participant` policies into a migration, *and* add a migration that drops the
+stale `USING (true)` policies by name, so a fresh `db reset` cannot resurrect them.
+
+**Step 4 — narrow `users_select_authenticated`** so `phone_number` / `backup_pin_hash` / `salt`
+are not readable by every logged-in account (§2), and rehash PINs with Argon2id + the per-user salt.
+
+**Step 5 —** switch the two `getSession()` routes to `getUser()` and scope
+`legacy-messages` deletion to the caller.
+
+---
+
+## 8. On the report itself
+
+Shape is the familiar coordinated-disclosure-with-leverage pattern: unsolicited, severities
+skewed upward, full details withheld pending contact, Signal handle, "reasonable remediation
+window."
+
+That said — **the technical content holds up.** The audit numbers match exactly, QRY-02 is
+confirmed live, and the QRY-01 drift claim is precisely correct. Treat the findings as real
+regardless of how you feel about the delivery. Also note there is nothing here you cannot verify
+yourself, as this document demonstrates: no payment or NDA is needed to reproduce any of it.

--- a/supabase/migrations/20260814000000_revoke_anon_execute_on_security_definer_rpcs.sql
+++ b/supabase/migrations/20260814000000_revoke_anon_execute_on_security_definer_rpcs.sql
@@ -1,0 +1,72 @@
+-- Step 1 of the 2026-08 security remediation.
+-- Context: docs/audits/2026-08-14-noir0x63-verification.md (QRY-02).
+--
+-- Every one of these functions is SECURITY DEFINER and was reachable by the
+-- `anon` role, i.e. by anyone holding the public anon key. Earlier migrations
+-- did `GRANT EXECUTE ... TO authenticated` but never revoked the default
+-- PUBLIC grant.
+--
+-- NOTE: revoking from PUBLIC alone is NOT sufficient here. Production ACLs show
+-- an *explicit* `anon=X/postgres` grant alongside the `=X/postgres` (PUBLIC)
+-- entry, so `anon` must be named explicitly in each REVOKE.
+--
+-- `service_role` holds its own explicit grant (`service_role=X/postgres`) and is
+-- unaffected by these revokes; it is re-granted below anyway for idempotence.
+
+-- --------------------------------------------------------------------------
+-- Only ever invoked with the service-role client, so lock them to service_role.
+--   delete_encrypted_data_only  -> src/app/api/user/nuclear-delete/route.js
+--   fn_create_message_recipients-> src/app/api/messages/send/route.js,
+--                                  src/app/api/chat/messages/route.js,
+--                                  src/lib/websocket/handlers/messages.js
+-- Ownership for the delete path is already enforced in the API route, which
+-- authenticates with getUser(), derives the internal id from auth_user_id, and
+-- requires an explicit DELETE_ALL_MY_DATA confirmation.
+-- --------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.delete_encrypted_data_only(uuid, uuid)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_encrypted_data_only(uuid, uuid)
+    TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.fn_create_message_recipients(uuid, jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_create_message_recipients(uuid, jsonb)
+    TO service_role;
+
+-- --------------------------------------------------------------------------
+-- No application callers anywhere in src/.
+-- --------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.sync_user_with_auth(text, uuid, text, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_user_with_auth(text, uuid, text, text)
+    TO service_role;
+
+-- --------------------------------------------------------------------------
+-- These must remain callable by `authenticated`.
+--   get_inactive_participants is called from the websocket send path, whose
+--   client is the anon key plus an `Authorization: Bearer <access_token>`
+--   header, so PostgREST resolves it to the `authenticated` role.
+--   The two voice-call functions have no callers today but are kept available
+--   to `authenticated` for the client that is expected to use them.
+-- Per-row ownership is enforced in the next migration (20260814000100).
+-- --------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.get_inactive_participants(uuid)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_inactive_participants(uuid)
+    TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_user_call_history(uuid, integer)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_user_call_history(uuid, integer)
+    TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_user_active_calls(uuid)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_user_active_calls(uuid)
+    TO authenticated, service_role;
+
+-- --------------------------------------------------------------------------
+-- Dead code. The body is literally `RETURN TRUE;` and there are zero callers
+-- in src/. It was a placeholder that never got implemented (QRY-07).
+-- --------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.is_otp_valid_extended(text, text, integer);

--- a/supabase/migrations/20260814000100_bind_security_definer_rpcs_to_auth_uid.sql
+++ b/supabase/migrations/20260814000100_bind_security_definer_rpcs_to_auth_uid.sql
@@ -1,0 +1,165 @@
+-- Step 2 of the 2026-08 security remediation.
+-- Context: docs/audits/2026-08-14-noir0x63-verification.md (QRY-03, QRY-04, NEW-02).
+--
+-- These SECURITY DEFINER functions took a user/conversation id as a parameter
+-- and trusted it. Any caller who could execute them could read any other user's
+-- call history, watch their active calls in real time, or dump the phone
+-- numbers of an arbitrary conversation's inactive participants.
+--
+-- The guard added below binds the request to the session instead of to the
+-- argument. `auth.uid() IS NOT NULL` lets service_role (which has no JWT, and
+-- therefore a NULL auth.uid()) continue to call these; `anon` is revoked in
+-- 20260814000000, so the only other caller is `authenticated`, which always
+-- has a non-NULL auth.uid().
+--
+-- Bodies below are reproduced from the *live* production definitions, which had
+-- drifted from this repo (they carry `SET search_path TO ''` and schema-
+-- qualified references that the committed migrations do not). Only the guard is
+-- new; the queries are unchanged.
+
+-- --------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_inactive_participants(conversation_uuid uuid)
+ RETURNS TABLE(user_id uuid, phone_number text, display_name text, username text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+BEGIN
+    -- Caller must be an active participant of the conversation being queried.
+    IF auth.uid() IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM public.conversation_participants cp
+        JOIN public.users u ON u.id = cp.user_id
+        WHERE cp.conversation_id = conversation_uuid
+          AND u.auth_user_id = auth.uid()
+          AND cp.left_at IS NULL
+    ) THEN
+        RAISE EXCEPTION 'Not authorized for this conversation';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        u.id,
+        u.phone_number,
+        u.display_name,
+        u.username
+    FROM public.users u
+    INNER JOIN public.conversation_participants cp ON u.id = cp.user_id
+    WHERE cp.conversation_id = conversation_uuid
+    AND cp.left_at IS NULL
+    AND public.is_user_inactive(u.id) = TRUE
+    AND u.phone_number IS NOT NULL;
+END;
+$function$;
+
+-- --------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_user_active_calls(p_user_id uuid)
+ RETURNS TABLE(id text, call_type text, status text, started_at timestamp with time zone, is_caller boolean, other_user_id uuid, other_user_username text, other_user_display_name text, other_user_avatar_url text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+BEGIN
+    -- Caller may only read their own calls.
+    IF auth.uid() IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.users u
+        WHERE u.id = p_user_id AND u.auth_user_id = auth.uid()
+    ) THEN
+        RAISE EXCEPTION 'Not authorized';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        vc.id,
+        vc.call_type,
+        vc.status,
+        vc.started_at,
+        (vc.caller_id = p_user_id) as is_caller,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN vc.recipient_id
+            ELSE vc.caller_id
+        END as other_user_id,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.username
+            ELSE caller_user.username
+        END as other_user_username,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.display_name
+            ELSE caller_user.display_name
+        END as other_user_display_name,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.avatar_url
+            ELSE caller_user.avatar_url
+        END as other_user_avatar_url
+    FROM public.voice_calls vc
+    LEFT JOIN public.users caller_user ON vc.caller_id = caller_user.id
+    LEFT JOIN public.users recipient_user ON vc.recipient_id = recipient_user.id
+    WHERE (vc.caller_id = p_user_id OR vc.recipient_id = p_user_id)
+    AND vc.status IN ('ringing', 'connected')
+    ORDER BY vc.started_at DESC;
+END;
+$function$;
+
+-- --------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_user_call_history(p_user_id uuid, p_limit integer DEFAULT 50)
+ RETURNS TABLE(id text, call_type text, status text, started_at timestamp with time zone, connected_at timestamp with time zone, ended_at timestamp with time zone, duration_seconds integer, is_caller boolean, other_user_id uuid, other_user_username text, other_user_display_name text, other_user_avatar_url text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+BEGIN
+    -- Caller may only read their own call history.
+    IF auth.uid() IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.users u
+        WHERE u.id = p_user_id AND u.auth_user_id = auth.uid()
+    ) THEN
+        RAISE EXCEPTION 'Not authorized';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        vc.id,
+        vc.call_type,
+        vc.status,
+        vc.started_at,
+        vc.connected_at,
+        vc.ended_at,
+        vc.duration_seconds,
+        (vc.caller_id = p_user_id) as is_caller,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN vc.recipient_id
+            ELSE vc.caller_id
+        END as other_user_id,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.username
+            ELSE caller_user.username
+        END as other_user_username,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.display_name
+            ELSE caller_user.display_name
+        END as other_user_display_name,
+        CASE
+            WHEN vc.caller_id = p_user_id THEN recipient_user.avatar_url
+            ELSE caller_user.avatar_url
+        END as other_user_avatar_url
+    FROM public.voice_calls vc
+    LEFT JOIN public.users caller_user ON vc.caller_id = caller_user.id
+    LEFT JOIN public.users recipient_user ON vc.recipient_id = recipient_user.id
+    WHERE vc.caller_id = p_user_id OR vc.recipient_id = p_user_id
+    ORDER BY vc.started_at DESC
+    LIMIT p_limit;
+END;
+$function$;
+
+-- CREATE OR REPLACE preserves the existing ACL, so these are redundant when
+-- 20260814000000 has already run. They are re-asserted anyway so this migration
+-- is self-sufficient if the two are ever applied out of order, and because
+-- REVOKE/GRANT are idempotent.
+REVOKE EXECUTE ON FUNCTION public.get_inactive_participants(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_inactive_participants(uuid) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_user_active_calls(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_user_active_calls(uuid) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_user_call_history(uuid, integer) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_user_call_history(uuid, integer) TO authenticated, service_role;

--- a/supabase/migrations/20260814000200_version_production_rls_policies.sql
+++ b/supabase/migrations/20260814000200_version_production_rls_policies.sql
@@ -1,0 +1,56 @@
+-- Step 3 of the 2026-08 security remediation.
+-- Context: docs/audits/2026-08-14-noir0x63-verification.md (QRY-01).
+--
+-- The July 2026 RLS fix was applied directly to production and never versioned.
+-- Production currently has `users_select_authenticated` and
+-- `messages_select_participant`; neither exists in any migration in this repo.
+-- Meanwhile the committed migrations still create anon-readable
+-- `USING (true)` SELECT policies on `users` and `messages`, so any fresh
+-- deploy, branch database, or `supabase db reset` reintroduces the original
+-- data leak.
+--
+-- This migration closes that gap in both directions: it drops the stale
+-- permissive policies by name, and creates the production policies. It is
+-- written to be a no-op against production and a real fix everywhere else.
+
+-- --------------------------------------------------------------------------
+-- Drop the permissive SELECT policies created by earlier migrations.
+-- Each of these is `USING (true)` with no role restriction, i.e. readable by
+-- `anon`. Named individually rather than dropped wholesale so that this stays
+-- reviewable and does not silently remove a policy added later.
+-- --------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Anyone can read user unique identifiers" ON public.users;
+DROP POLICY IF EXISTS "Anyone can view user profiles"           ON public.users;
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON public.users;
+DROP POLICY IF EXISTS "Users can read basic user info for search" ON public.users;
+
+DROP POLICY IF EXISTS "Users can read all messages" ON public.messages;
+
+-- --------------------------------------------------------------------------
+-- Recreate the policies that production actually runs.
+-- --------------------------------------------------------------------------
+
+-- WARNING: `USING (true)` here is scoped to the `authenticated` role, not to
+-- `anon` -- but it still lets any single logged-in account read every row of
+-- `users`, which includes `phone_number`, `backup_pin_hash` and `salt`.
+-- That is Step 4 of the remediation (narrow this to non-sensitive columns and
+-- rehash PINs with Argon2id + the per-user salt) and is deliberately NOT
+-- changed here, so that this migration reproduces production exactly.
+-- See §2 of the verification document.
+DROP POLICY IF EXISTS users_select_authenticated ON public.users;
+CREATE POLICY users_select_authenticated ON public.users
+    FOR SELECT TO authenticated
+    USING (true);
+
+DROP POLICY IF EXISTS messages_select_participant ON public.messages;
+CREATE POLICY messages_select_participant ON public.messages
+    FOR SELECT TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1
+            FROM public.conversation_participants cp
+            JOIN public.users u ON u.id = cp.user_id
+            WHERE cp.conversation_id = messages.conversation_id
+              AND u.auth_user_id = auth.uid()
+        )
+    );


### PR DESCRIPTION
Steps 1–3 of the remediation for the audit archived in `docs/audits/`. Three migrations, no code changes.

**Nothing here is applied to production.** There is no CI step in this repo that applies migrations, so merging this ships files only — someone has to apply them deliberately.

## `20260814000000` — revoke anon EXECUTE (closes the live Critical)

Six `SECURITY DEFINER` functions were executable by `anon`, i.e. by anyone holding the public anon key. Earlier migrations did `GRANT EXECUTE ... TO authenticated` but never revoked the default `PUBLIC` grant.

> **Worth knowing:** the audit's remediation (`REVOKE EXECUTE FROM PUBLIC`) would **not** have closed this. Production ACLs carry an *explicit* `anon=X/postgres` grant alongside the `=X/postgres` PUBLIC entry, so `anon` has to be named in each REVOKE. `service_role` holds its own explicit grant and is unaffected.

Locked to `service_role` (verified: this is the only client all their callers use):
- `delete_encrypted_data_only` — `api/user/nuclear-delete/route.js`, which already gates on `getUser()`, derives the internal id from `auth_user_id`, and demands a `DELETE_ALL_MY_DATA` confirmation
- `fn_create_message_recipients` — `api/messages/send`, `api/chat/messages`, `websocket/handlers/messages.js`
- `sync_user_with_auth` — no callers anywhere in `src/`

Kept available to `authenticated`, revoked from `anon`:
- `get_inactive_participants`, `get_user_call_history`, `get_user_active_calls`

`is_otp_valid_extended` is dropped — its body is `RETURN TRUE;` and it has zero callers.

## `20260814000100` — bind to the session, not the argument

The three read functions took an id and trusted it, so any caller could read another user's call history, watch their active calls live, or dump the phone numbers of an arbitrary conversation's inactive participants. The guard binds to `auth.uid()`; `auth.uid() IS NOT NULL` keeps `service_role` (no JWT) working.

Bodies are reproduced from the **live** definitions, not this repo's — production had drifted and carries `SET search_path TO ''` plus schema-qualified references that the committed migrations lack. Only the guard is new.

## `20260814000200` — version the drift

Production runs `users_select_authenticated` and `messages_select_participant`, neither of which exists in any migration here. The committed migrations still create anon-readable `USING (true)` policies on `users` and `messages`, so a fresh deploy or `db reset` reintroduces the original leak. This drops the stale policies by name and creates the real ones — a no-op against production, a genuine fix everywhere else.

## Not included

**Step 4.** `users_select_authenticated` is `USING (true)` for `authenticated`, and `users` holds `phone_number`, `backup_pin_hash` and `salt` — so any one logged-in account can read all three for every user, and the PIN is unsalted SHA-256. That needs a column-narrowing decision plus a PIN rehash to Argon2id, which is a bigger change than this PR; it is flagged in an inline comment in `20260814000200`. Reviewer judgement wanted on whether to split the sensitive columns out of `users` or use column-level grants.

## Review notes

These migrations have **not** been executed anywhere — no local Postgres available and I deliberately did not apply them to prod. Please dry-run against a branch database before applying. The riskiest single statement is the `CREATE OR REPLACE` on `get_inactive_participants`, since it sits in the live message-send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)