### PR TITLE
fix(security): close the wave-2 advisories (RLS, XSS sink, token exposure, KDFs)

### DIFF
--- a/src/app/admin/integrations-form.jsx
+++ b/src/app/admin/integrations-form.jsx
@@ -13,7 +13,6 @@ export function IntegrationsManager({ initial }) {
   const [kind, setKind] = useState("crawlproof");
   const [name, setName] = useState("Crawlproof");
   const [origin, setOrigin] = useState("");
-  const [revealed, setRevealed] = useState({});
   const [copied, setCopied] = useState(null);
   const [error, setError] = useState(null);
   const [justCreatedToken, setJustCreatedToken] = useState(null);
@@ -114,8 +113,6 @@ export function IntegrationsManager({ initial }) {
         ) : (
           <ul style={{ listStyle: "none", padding: 0, display: "flex", flexDirection: "column", gap: "0.5rem" }}>
             {items.map((it) => {
-              const show = !!revealed[it.id];
-              const masked = `${it.access_token.slice(0, 8)}…${it.access_token.slice(-4)}`;
               return (
                 <li key={it.id} style={{ borderRadius: "0.375rem", border: `1px solid ${borderColor}`, padding: "0.75rem", fontSize: "0.875rem" }}>
                   <div style={{ display: "flex", justifyContent: "space-between", gap: "0.75rem", alignItems: "flex-start" }}>
@@ -132,16 +129,11 @@ export function IntegrationsManager({ initial }) {
                       </div>
                       <div style={{ marginTop: "0.5rem", display: "flex", alignItems: "center", gap: "0.5rem" }}>
                         <code style={{ flex: 1, wordBreak: "break-all", borderRadius: "0.25rem", border: `1px solid ${borderColor}`, background: "var(--color-bg-secondary)", padding: "0.25rem 0.5rem", fontSize: "0.75rem" }}>
-                          {show ? it.access_token : masked}
+                          {it.token_hint}
                         </code>
-                        <button type="button" onClick={() => setRevealed((p) => ({ ...p, [it.id]: !p[it.id] }))}
-                          style={{ fontSize: "0.75rem", color: mutedColor, background: "none", border: "none", cursor: "pointer" }}>
-                          {show ? "Hide" : "Reveal"}
-                        </button>
-                        <button type="button" onClick={() => copy(it.id, it.access_token)}
-                          style={{ fontSize: "0.75rem", color: mutedColor, background: "none", border: "none", cursor: "pointer" }}>
-                          {copied === it.id ? "Copied" : "Copy"}
-                        </button>
+                        <span style={{ fontSize: "0.75rem", color: mutedColor }}>
+                          shown once at creation
+                        </span>
                       </div>
                     </div>
                     <button type="button" onClick={() => onRevoke(it)} disabled={pending}

--- a/src/app/admin/page.jsx
+++ b/src/app/admin/page.jsx
@@ -27,7 +27,17 @@ export default async function AdminPage() {
   const [{ data: integrations }, { data: posts }] = await Promise.all([
     svc.from('autoblog_integrations')
       .select('id, name, kind, access_token, request_count, last_used_at, created_at')
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .then(({ data, error }) => ({
+        // The raw bearer token must never reach the browser: anything handed to a client
+        // component is serialised into the RSC payload, where masking in JSX is cosmetic.
+        // Only a non-reversible hint travels over the wire.
+        data: data?.map(({ access_token, ...rest }) => ({
+          ...rest,
+          token_hint: access_token ? `${access_token.slice(0, 4)}…${access_token.slice(-4)}` : '',
+        })),
+        error,
+      })),
     svc.from('blog_posts')
       .select('id, slug, title, source, published_at')
       .order('published_at', { ascending: false })

--- a/src/app/api/auth/backup-pin/route.js
+++ b/src/app/api/auth/backup-pin/route.js
@@ -101,13 +101,15 @@ async function authenticateUser(request) {
 	}
 }
 
-// scrypt work factors. N=16384/r=8/p=1 is the Node default and costs ~16MB and
-// tens of milliseconds per derivation -- enough to make an offline sweep of the
-// 6-12 digit PIN keyspace impractical per user, and the per-user salt means
-// there is no shared work across users.
-const SCRYPT_N = 16384;
+// scrypt work factors. N=2^17/r=8/p=1 is OWASP's recommended minimum; the previous
+// N=16384 (Node's default) cost only ~16MB per derivation, which left the 6-12 digit
+// PIN keyspace within reach of an offline GPU sweep. The per-user salt means there is
+// no shared work across users on top of that.
+const SCRYPT_N = 131072;
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;
+// scrypt needs roughly 128 * N * r bytes; Node's default 32MB cap would reject N=2^17.
+const SCRYPT_MAXMEM = 192 * 1024 * 1024;
 const SCRYPT_KEYLEN = 64;
 const SCRYPT_SALT_BYTES = 16;
 export const PIN_ALGORITHM = `scrypt-n${SCRYPT_N}-r${SCRYPT_R}-p${SCRYPT_P}`;
@@ -126,7 +128,12 @@ export const PIN_ALGORITHM = `scrypt-n${SCRYPT_N}-r${SCRYPT_R}-p${SCRYPT_P}`;
 async function hashPin(pin, saltHex) {
 	const salt = saltHex ?? randomBytes(SCRYPT_SALT_BYTES).toString('hex');
 	const derived = /** @type {Buffer} */ (
-		await scrypt(pin, salt, SCRYPT_KEYLEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P })
+		await scrypt(pin, salt, SCRYPT_KEYLEN, {
+			N: SCRYPT_N,
+			r: SCRYPT_R,
+			p: SCRYPT_P,
+			maxmem: SCRYPT_MAXMEM
+		})
 	);
 	return { hash: derived.toString('hex'), salt, algorithm: PIN_ALGORITHM };
 }

--- a/src/app/api/auth/coinpay/callback/route.js
+++ b/src/app/api/auth/coinpay/callback/route.js
@@ -182,6 +182,15 @@ export async function GET(request) {
 			return redirectError(appOrigin, 'coinpay_no_email');
 		}
 
+		// The email is what binds this OIDC identity to a QryptChat account, so an unverified
+		// one would let whoever controls the provider-side address take over that account.
+		// Only an explicit affirmative counts — a missing claim is not a verified claim.
+		const emailVerified = claims.email_verified === true || claims.email_verified === 'true';
+		if (!emailVerified) {
+			console.error('coinpay/callback: refusing to link an unverified email');
+			return redirectError(appOrigin, 'coinpay_email_unverified');
+		}
+
 		const serviceSupabase = createServiceClient();
 
 		// --- a) Find-or-create Supabase auth user by email ---

--- a/src/app/api/conversations/delete/route.js
+++ b/src/app/api/conversations/delete/route.js
@@ -1,8 +1,11 @@
 /**
  * @fileoverview Delete Conversation API Endpoint
- * Handles removing a user's participation and their data from a conversation
- * For direct messages: deletes the entire conversation if user is a participant
- * For groups: only removes the user's participation and their messages/files
+ * Handles removing a user's participation and their data from a conversation.
+ *
+ * A participant may only destroy rows they own — their own messages, their own file
+ * attachments and their own participation — whatever the conversation type. The shared
+ * conversation row and anything still belonging to other people is removed only once the
+ * last active participant has left, at which point there is nobody left to lose data.
  */
 
 import { NextResponse } from 'next/server';
@@ -84,42 +87,63 @@ export const POST = withAuth(async ({ request, locals }) => {
 			return NextResponse.json({ error: 'Failed to fetch conversation details' }, { status: 500 });
 		}
 
-		const isDirectMessage = conversation.type === 'direct';
+		// Every participant — direct or group — may only remove what belongs to them.
+		// Dependent rows (deliveries, message_recipients, message_status, encrypted_files)
+		// are ON DELETE CASCADE from messages, so deleting the sender's own messages is enough.
+		const { error: ownMessagesError } = await supabase
+			.from('messages')
+			.delete()
+			.eq('conversation_id', conversationId)
+			.eq('sender_id', internalUserId);
 
-		if (isDirectMessage) {
-			// For direct messages, delete everything for all participants
-			console.log(`Deleting direct message conversation ${conversationId} for all participants`);
+		if (ownMessagesError) {
+			console.error('Error deleting user messages:', ownMessagesError);
+			return NextResponse.json({ error: 'Failed to delete your messages' }, { status: 500 });
+		}
 
-			// Use service role client to bypass RLS policies for deletion
-			const serviceClient = getServiceRoleClient();
-			console.log('🔑 Using service role client to bypass RLS for deletion');
+		const { error: ownFilesError } = await supabase
+			.from('file_attachments')
+			.delete()
+			.eq('conversation_id', conversationId)
+			.eq('uploaded_by', internalUserId);
 
-			// Step 1: Get all message IDs for this conversation
-			const { data: messages, error: messagesQueryError } = await serviceClient
-				.from('messages')
-				.select('id')
-				.eq('conversation_id', conversationId);
+		if (ownFilesError) {
+			console.error('Error deleting user file attachments:', ownFilesError);
+		}
 
-			if (messagesQueryError) {
-				console.error('Error querying messages:', messagesQueryError);
-				return NextResponse.json({ error: 'Failed to query messages' }, { status: 500 });
-			}
+		const { error: leaveError } = await supabase
+			.from('conversation_participants')
+			.delete()
+			.eq('conversation_id', conversationId)
+			.eq('user_id', internalUserId);
 
-			const messageIds = messages?.map(m => m.id) || [];
+		if (leaveError) {
+			console.error('Error removing user participation:', leaveError);
+			return NextResponse.json({ error: 'Failed to leave conversation' }, { status: 500 });
+		}
 
-			// Step 2: Delete SMS notifications (references conversation_id and message_id)
-			if (messageIds.length > 0) {
-				const { error: smsError } = await serviceClient
-					.from('sms_notifications')
-					.delete()
-					.in('message_id', messageIds);
+		// Garbage-collect the shared conversation only once nobody is left in it.
+		const serviceClient = getServiceRoleClient();
+		const { data: remaining, error: remainingError } = await serviceClient
+			.from('conversation_participants')
+			.select('id')
+			.eq('conversation_id', conversationId)
+			.is('left_at', null)
+			.limit(1);
 
-				if (smsError) {
-					console.error('Error deleting SMS notifications:', smsError);
-				}
-			}
+		if (remainingError) {
+			console.error('Error counting remaining participants:', remainingError);
+			return NextResponse.json({ error: 'Failed to finalise deletion' }, { status: 500 });
+		}
 
-			// Also delete SMS notifications by conversation_id
+		const isOrphaned = (remaining?.length ?? 0) === 0;
+		console.log(
+			`🗑️ ${conversation.type} conversation ${conversationId}: caller removed, orphaned=${isOrphaned}`
+		);
+
+		if (isOrphaned) {
+			// Nobody is left in this conversation, so the leftovers belong to no one. Rows that
+			// hang off messages cascade; the rest are cleaned up explicitly.
 			const { error: smsConvError } = await serviceClient
 				.from('sms_notifications')
 				.delete()
@@ -129,55 +153,6 @@ export const POST = withAuth(async ({ request, locals }) => {
 				console.error('Error deleting SMS notifications by conversation:', smsConvError);
 			}
 
-			// Step 3: Delete deliveries (references message_id)
-			if (messageIds.length > 0) {
-				const { error: deliveriesError } = await serviceClient
-					.from('deliveries')
-					.delete()
-					.in('message_id', messageIds);
-
-				if (deliveriesError) {
-					console.error('Error deleting deliveries:', deliveriesError);
-				}
-			}
-
-			// Step 4: Delete message_recipients (references message_id)
-			if (messageIds.length > 0) {
-				const { error: recipientsError } = await serviceClient
-					.from('message_recipients')
-					.delete()
-					.in('message_id', messageIds);
-
-				if (recipientsError) {
-					console.error('Error deleting message recipients:', recipientsError);
-				}
-			}
-
-			// Step 5: Delete message_status (references message_id)
-			if (messageIds.length > 0) {
-				const { error: statusError } = await serviceClient
-					.from('message_status')
-					.delete()
-					.in('message_id', messageIds);
-
-				if (statusError) {
-					console.error('Error deleting message status:', statusError);
-				}
-			}
-
-			// Step 6: Delete encrypted_files (references message_id)
-			if (messageIds.length > 0) {
-				const { error: encryptedFilesError } = await serviceClient
-					.from('encrypted_files')
-					.delete()
-					.in('message_id', messageIds);
-
-				if (encryptedFilesError) {
-					console.error('Error deleting encrypted files:', encryptedFilesError);
-				}
-			}
-
-			// Step 7: Delete all messages
 			const { error: messagesError } = await serviceClient
 				.from('messages')
 				.delete()
@@ -188,7 +163,6 @@ export const POST = withAuth(async ({ request, locals }) => {
 				return NextResponse.json({ error: 'Failed to delete messages' }, { status: 500 });
 			}
 
-			// Step 8: Delete typing_indicators
 			const { error: typingError } = await serviceClient
 				.from('typing_indicators')
 				.delete()
@@ -198,7 +172,6 @@ export const POST = withAuth(async ({ request, locals }) => {
 				console.error('Error deleting typing indicators:', typingError);
 			}
 
-			// Step 9: Delete all participants
 			const { error: participantsError } = await serviceClient
 				.from('conversation_participants')
 				.delete()
@@ -209,7 +182,6 @@ export const POST = withAuth(async ({ request, locals }) => {
 				return NextResponse.json({ error: 'Failed to delete participants' }, { status: 500 });
 			}
 
-			// Step 10: Delete the conversation
 			const { error: conversationError } = await serviceClient
 				.from('conversations')
 				.delete()
@@ -220,50 +192,10 @@ export const POST = withAuth(async ({ request, locals }) => {
 				return NextResponse.json({ error: 'Failed to delete conversation' }, { status: 500 });
 			}
 
-			console.log(`✅ Successfully deleted direct message conversation ${conversationId}`);
-		} else {
-			// For group conversations, only delete user's own data
-			console.log(`Removing user ${internalUserId} from group conversation ${conversationId}`);
-
-			// Delete only the user's messages
-			const { error: messagesError } = await supabase
-				.from('messages')
-				.delete()
-				.eq('conversation_id', conversationId)
-				.eq('sender_id', internalUserId);
-
-			if (messagesError) {
-				console.error('Error deleting user messages:', messagesError);
-				return NextResponse.json({ error: 'Failed to delete your messages' }, { status: 500 });
-			}
-
-			// Delete only the user's file attachments
-			const { error: filesError } = await supabase
-				.from('file_attachments')
-				.delete()
-				.eq('conversation_id', conversationId)
-				.eq('uploaded_by', internalUserId);
-
-			if (filesError) {
-				console.error('Error deleting user file attachments:', filesError);
-			}
-
-			// Remove user's participation
-			const { error: participantError } = await supabase
-				.from('conversation_participants')
-				.delete()
-				.eq('conversation_id', conversationId)
-				.eq('user_id', internalUserId);
-
-			if (participantError) {
-				console.error('Error removing user participation:', participantError);
-				return NextResponse.json({ error: 'Failed to leave conversation' }, { status: 500 });
-			}
-
-			console.log(`✅ Successfully removed user ${internalUserId} from group conversation ${conversationId}`);
+			console.log(`✅ Garbage-collected orphaned conversation ${conversationId}`);
 		}
 
-		return NextResponse.json({ success: true });
+		return NextResponse.json({ success: true, conversationRemoved: isOrphaned });
 	} catch (error) {
 		console.error('Delete conversation error:', error);
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/conversations/delete/route.test.js
+++ b/src/app/api/conversations/delete/route.test.js
@@ -58,17 +58,37 @@ describe('POST /api/conversations/delete', () => {
 		vi.clearAllMocks();
 	});
 
-	it('keeps a two-member group and removes only the requesting participant data', async () => {
+	/**
+	 * Service-role view of who is still in the conversation after the caller leaves.
+	 * @param {Array<{id: string}>} rows
+	 */
+	function remainingParticipants(rows) {
+		// Doubles as the delete target used by the orphan cleanup, so it carries both
+		// the select chain and delete/eq.
+		const query = {
+			error: null,
+			select: vi.fn(() => query),
+			delete: vi.fn(() => query),
+			eq: vi.fn(() => query),
+			is: vi.fn(() => query),
+			limit: vi.fn().mockResolvedValue({ data: rows, error: null })
+		};
+		return query;
+	}
+
+	/**
+	 * Wire up the happy path for a caller leaving `type` conversation, with `rows`
+	 * describing who remains behind afterwards.
+	 */
+	function setup({ type, rows }) {
 		const messages = deleteQuery();
 		const files = deleteQuery();
 		const participantDelete = deleteQuery();
-		participantDelete.count = 2;
-		participantDelete.select = vi.fn(() => participantDelete);
 		let participantQueries = 0;
 
 		mocks.from.mockImplementation((table) => {
 			if (table === 'users') return selectSingle({ id: 'internal-user-id' });
-			if (table === 'conversations') return selectSingle({ type: 'group' });
+			if (table === 'conversations') return selectSingle({ type });
 			if (table === 'messages') return messages;
 			if (table === 'file_attachments') return files;
 			if (table === 'conversation_participants') {
@@ -78,15 +98,69 @@ describe('POST /api/conversations/delete', () => {
 			throw new Error(`Unexpected table: ${table}`);
 		});
 
+		const serviceTables = {
+			conversation_participants: remainingParticipants(rows),
+			messages: deleteQuery(),
+			sms_notifications: deleteQuery(),
+			typing_indicators: deleteQuery(),
+			conversations: deleteQuery()
+		};
+		mocks.getServiceRoleClient.mockReturnValue({
+			from: vi.fn((table) => serviceTables[table])
+		});
+
+		return { messages, files, participantDelete, serviceTables };
+	}
+
+	it('keeps a two-member group and removes only the requesting participant data', async () => {
+		const { messages, files, participantDelete, serviceTables } = setup({
+			type: 'group',
+			rows: [{ id: 'someone-else' }]
+		});
+
 		const { POST } = await import('./route.js');
 		const response = await POST({
 			json: vi.fn().mockResolvedValue({ conversationId: 'group-1' })
 		});
 
 		expect(response.status).toBe(200);
-		expect(mocks.getServiceRoleClient).not.toHaveBeenCalled();
 		expect(messages.eq).toHaveBeenCalledWith('sender_id', 'internal-user-id');
 		expect(files.eq).toHaveBeenCalledWith('uploaded_by', 'internal-user-id');
 		expect(participantDelete.eq).toHaveBeenCalledWith('user_id', 'internal-user-id');
+		expect(serviceTables.conversations.delete).not.toHaveBeenCalled();
+	});
+
+	// GHSA-xm8x-rpr6-4j7h: a single participant used to be able to hard-delete an entire
+	// direct conversation -- every other party's ciphertext and files included.
+	it('does not destroy a direct conversation while the other party is still in it', async () => {
+		const { messages, serviceTables } = setup({
+			type: 'direct',
+			rows: [{ id: 'the-other-party' }]
+		});
+
+		const { POST } = await import('./route.js');
+		const response = await POST({
+			json: vi.fn().mockResolvedValue({ conversationId: 'direct-1' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ success: true, conversationRemoved: false });
+		// The caller's own messages go; nothing wipes the conversation wholesale.
+		expect(messages.eq).toHaveBeenCalledWith('sender_id', 'internal-user-id');
+		expect(serviceTables.messages.delete).not.toHaveBeenCalled();
+		expect(serviceTables.conversations.delete).not.toHaveBeenCalled();
+	});
+
+	it('garbage-collects the conversation once the last participant leaves', async () => {
+		const { serviceTables } = setup({ type: 'direct', rows: [] });
+
+		const { POST } = await import('./route.js');
+		const response = await POST({
+			json: vi.fn().mockResolvedValue({ conversationId: 'direct-2' })
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ success: true, conversationRemoved: true });
+		expect(serviceTables.conversations.delete).toHaveBeenCalled();
 	});
 });

--- a/src/app/api/users/search/route.js
+++ b/src/app/api/users/search/route.js
@@ -1,5 +1,17 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase.js';
+import { getServiceRoleClient } from '@/lib/supabase/service-role.js';
+
+// Directory search has to reach across every user, which is the one thing the narrowed
+// `users` SELECT policy no longer allows the caller's own role to do. The lookup therefore
+// runs as the service role *after* the session has been verified, and only the masked
+// projection at the bottom of this handler ever leaves the server.
+
+// A one-character query against `phone_number` turns this endpoint into an existence
+// oracle: type a prefix, learn whether that number is registered. Phone matching is
+// therefore only offered once the caller has supplied enough digits to already know the
+// number they are asking about.
+const MIN_PHONE_QUERY_LENGTH = 7;
 
 
 export async function GET(request, { params } = {}) {
@@ -36,10 +48,19 @@ export async function GET(request, { params } = {}) {
 		
 		// Enhanced fuzzy search across multiple fields with relevance scoring
 		// Search by username, display_name (full name), phone_number, and unique_identifier
-		const { data, error } = await supabase
+		const filters = [
+			`username.ilike.%${sanitizedQuery}%`,
+			`display_name.ilike.%${sanitizedQuery}%`,
+			`unique_identifier.ilike.%${sanitizedQuery}%`
+		];
+		if (sanitizedQuery.length >= MIN_PHONE_QUERY_LENGTH) {
+			filters.push(`phone_number.ilike.%${sanitizedQuery}%`);
+		}
+
+		const { data, error } = await getServiceRoleClient()
 			.from('users')
 			.select('id, username, display_name, avatar_url, phone_number, unique_identifier')
-			.or(`username.ilike.%${sanitizedQuery}%,display_name.ilike.%${sanitizedQuery}%,phone_number.ilike.%${sanitizedQuery}%,unique_identifier.ilike.%${sanitizedQuery}%`)
+			.or(filters.join(','))
 			.neq('auth_user_id', user.id) // Exclude current user by the auth UUID
 			.limit(50); // Get more results for better sorting
 	

--- a/src/app/api/users/search/route.test.js
+++ b/src/app/api/users/search/route.test.js
@@ -7,11 +7,16 @@ const mocks = vi.hoisted(() => ({
 	or: vi.fn(),
 	neq: vi.fn(),
 	limit: vi.fn(),
-	createSupabaseServerClient: vi.fn()
+	createSupabaseServerClient: vi.fn(),
+	getServiceRoleClient: vi.fn()
 }));
 
 vi.mock('@/lib/supabase.js', () => ({
 	createSupabaseServerClient: mocks.createSupabaseServerClient
+}));
+
+vi.mock('@/lib/supabase/service-role.js', () => ({
+	getServiceRoleClient: mocks.getServiceRoleClient
 }));
 
 describe('user search', () => {
@@ -29,9 +34,11 @@ describe('user search', () => {
 		mocks.neq.mockReturnValue({ limit: mocks.limit });
 		mocks.limit.mockResolvedValue({ data: [], error: null });
 		mocks.createSupabaseServerClient.mockResolvedValue({
-			auth: { getUser: mocks.getUser },
-			from: mocks.from
+			auth: { getUser: mocks.getUser }
 		});
+		// The directory lookup has to outrun the narrowed `users` SELECT policy, so it
+		// runs as the service role once the session has been verified.
+		mocks.getServiceRoleClient.mockReturnValue({ from: mocks.from });
 	});
 
 	it('excludes the authenticated user with the auth_user_id column', async () => {
@@ -41,6 +48,27 @@ describe('user search', () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.neq).toHaveBeenCalledWith('auth_user_id', 'auth-user-1');
+	});
+
+	// A one-character query matched against phone_number turned this endpoint into an
+	// existence oracle for registered numbers.
+	it('only matches phone numbers once the query is long enough to not be an oracle', async () => {
+		const { GET } = await import('./route.js');
+
+		await GET(new Request('https://example.com/api/users/search?q=555'));
+		expect(mocks.or.mock.calls[0][0]).not.toContain('phone_number');
+
+		vi.clearAllMocks();
+		mocks.getUser.mockResolvedValue({ data: { user: { id: 'auth-user-1' } }, error: null });
+		mocks.from.mockReturnValue({ select: mocks.select });
+		mocks.select.mockReturnValue({ or: mocks.or });
+		mocks.or.mockReturnValue({ neq: mocks.neq });
+		mocks.neq.mockReturnValue({ limit: mocks.limit });
+		mocks.limit.mockResolvedValue({ data: [], error: null });
+		mocks.getServiceRoleClient.mockReturnValue({ from: mocks.from });
+
+		await GET(new Request('https://example.com/api/users/search?q=5551234'));
+		expect(mocks.or.mock.calls[0][0]).toContain('phone_number');
 	});
 
 	it('does not query users when sanitized search text is empty', async () => {

--- a/src/lib/components/chat/MessageItem.jsx
+++ b/src/lib/components/chat/MessageItem.jsx
@@ -16,7 +16,10 @@ export default function MessageItem({ message, showAvatar = true, showTimestamp 
   const detectedFormat = detectTextFormat(content);
   const isAsciiArt = message.metadata?.isAsciiArt === true || detectedFormat.type === 'ascii-art';
   const isCodeBlock = detectedFormat.type === 'code' || detectedFormat.language !== null;
-  const contentWithLinks = detectedFormat.type === 'plain' ? convertUrlsToLinks(content) : content;
+  // Message content is attacker-controlled. It only ever reaches the HTML sink below through
+  // convertUrlsToLinks(), which escapes every character it did not generate itself. Never pass
+  // `content` here directly, whatever the detected format says.
+  const contentWithLinks = convertUrlsToLinks(content);
 
   function formatTime(ts) {
     return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });

--- a/src/lib/crypto/encrypted-key-backup.js
+++ b/src/lib/crypto/encrypted-key-backup.js
@@ -263,7 +263,7 @@ export class EncryptedKeyBackup {
 				
 				// Key derivation parameters
 				salt,
-				iterations: 100000,
+				iterations: 600000,
 				
 				// Metadata
 				phoneNumber,

--- a/src/lib/crypto/master-key-derivation.js
+++ b/src/lib/crypto/master-key-derivation.js
@@ -12,10 +12,10 @@ export class MasterKeyDerivation {
 	 * Derive master key from phone number and PIN
 	 * @param {string} phoneNumber - User's phone number
 	 * @param {string} pin - User's PIN or password
-	 * @param {number} iterations - PBKDF2 iterations (default: 100000)
+	 * @param {number} iterations - PBKDF2 iterations (default: 600000)
 	 * @returns {Promise<Uint8Array>} 256-bit master key
 	 */
-	static async deriveFromCredentials(phoneNumber, pin, iterations = 100000) {
+	static async deriveFromCredentials(phoneNumber, pin, iterations = 600000) {
 		if (typeof window === 'undefined') {
 			throw new Error('Master key derivation only available in browser');
 		}
@@ -74,7 +74,7 @@ export class MasterKeyDerivation {
 	 * @param {number} iterations - PBKDF2 iterations
 	 * @returns {Promise<Uint8Array>} 256-bit master key
 	 */
-	static async deriveWithSalt(phoneNumber, pin, salt, iterations = 100000) {
+	static async deriveWithSalt(phoneNumber, pin, salt, iterations = 600000) {
 		if (typeof window === 'undefined') {
 			throw new Error('Master key derivation only available in browser');
 		}

--- a/src/lib/crypto/private-key-manager.js
+++ b/src/lib/crypto/private-key-manager.js
@@ -13,6 +13,19 @@ import { postQuantumEncryption } from './post-quantum-encryption.js';
 const EXPORT_VERSION = '3.0'; // Post-quantum: ChaCha20-Poly1305 + HKDF
 
 /**
+ * PBKDF2-HMAC-SHA256 work factor for newly written exports. OWASP's guidance is
+ * 600,000 iterations; the previous 100,000 left a password-protected key export
+ * cheap enough to attack offline on a GPU.
+ */
+const PBKDF2_ITERATIONS = 600000;
+
+/**
+ * Exports written before the uplift carry no `kdfIterations` field. They must keep
+ * deriving at the count they were written with, or they stop importing entirely.
+ */
+const LEGACY_PBKDF2_ITERATIONS = 100000;
+
+/**
  * Private key import/export manager
  */
 export class PrivateKeyManager {
@@ -77,7 +90,8 @@ export class PrivateKeyManager {
 				encryptedKeys: Base64.encode(ciphertext),
 				pbkdfSalt: Base64.encode(pbkdfSalt),
 				hkdfSalt: Base64.encode(hkdfSalt),
-				nonce: Base64.encode(nonce)
+				nonce: Base64.encode(nonce),
+				kdfIterations: PBKDF2_ITERATIONS
 			};
 
 			// Clear sensitive data from memory
@@ -132,7 +146,8 @@ export class PrivateKeyManager {
 				const hkdfSalt = new Uint8Array(Base64.decode(parsedData.hkdfSalt));
 				const nonce = new Uint8Array(Base64.decode(parsedData.nonce));
 
-				const passwordKey = await this._deriveKeyFromPassword(password, pbkdfSalt);
+				const kdfIterations = parsedData.kdfIterations ?? LEGACY_PBKDF2_ITERATIONS;
+				const passwordKey = await this._deriveKeyFromPassword(password, pbkdfSalt, kdfIterations);
 				const chachaKey = await HKDF.derive(passwordKey, hkdfSalt, 'QryptChat-KeyBackup-ChaCha20', 32);
 
 				let plaintext;
@@ -164,7 +179,11 @@ export class PrivateKeyManager {
 
 				let decryptedBuffer;
 				// Attempt 1: PBKDF2 (current derivation)
-				const pbkdf2Key = await this._deriveKeyFromPassword(password, salt);
+				const pbkdf2Key = await this._deriveKeyFromPassword(
+					password,
+					salt,
+					parsedData.kdfIterations ?? LEGACY_PBKDF2_ITERATIONS
+				);
 				try {
 					decryptedBuffer = await tryDecrypt(pbkdf2Key);
 				} catch {
@@ -240,7 +259,7 @@ export class PrivateKeyManager {
 	 * @returns {Promise<Uint8Array>} Derived key
 	 * @private
 	 */
-	async _deriveKeyFromPassword(password, salt) {
+	async _deriveKeyFromPassword(password, salt, iterations = PBKDF2_ITERATIONS) {
 		// Convert password to bytes
 		const passwordBytes = new TextEncoder().encode(password);
 		
@@ -253,12 +272,13 @@ export class PrivateKeyManager {
 			['deriveKey']
 		);
 
-		// Derive key using PBKDF2 with 100,000+ iterations (OWASP recommendation)
+		// Derive key using PBKDF2; the caller supplies the count recorded with the export
+		// so that older files keep importing at the work factor they were written with.
 		const derivedCryptoKey = await crypto.subtle.deriveKey(
 			{
 				name: 'PBKDF2',
 				salt: salt,
-				iterations: 100000,
+				iterations: iterations,
 				hash: 'SHA-256'
 			},
 			keyMaterial,

--- a/src/lib/server/rate-limiter.js
+++ b/src/lib/server/rate-limiter.js
@@ -97,8 +97,17 @@ export const smsGlobalDailyLimiter = new RateLimiter({
 	windowMs: 24 * 60 * 60 * 1000
 });
 
+/**
+ * Hops in front of this process that are ours and therefore trustworthy.
+ *
+ * Defaults to 1 because every shipped deployment of this app (railway.toml, Dockerfile)
+ * runs behind exactly one platform proxy that overwrites X-Forwarded-For. A
+ * direct-to-internet deployment must set TRUSTED_PROXY_COUNT=0 explicitly, which makes
+ * the forwarding headers untrusted rather than merely undocumented.
+ */
 export function parseTrustedProxyCount(value = process.env.TRUSTED_PROXY_COUNT) {
-	const raw = String(value ?? '0').trim();
+	if (value === undefined || value === null || String(value).trim() === '') return 1;
+	const raw = String(value).trim();
 	if (!/^\d+$/.test(raw)) return 0;
 	const count = Number(raw);
 	return Number.isSafeInteger(count) ? count : 0;
@@ -141,16 +150,17 @@ export function getClientIp(request) {
 				return parts[parts.length - trustedProxyCount];
 			}
 		}
+
+		// X-Real-IP is only meaningful once a trusted hop has set it (nginx real_ip and
+		// similar); it is otherwise just another attacker-controlled header.
+		const realIp = request.headers.get('x-real-ip');
+		if (realIp) return realIp;
 	}
 
-	// Fallback: use X-Real-IP (set by nginx real_ip module after trusted proxy
-	// processing) or fall through to 'unknown'.  When TRUSTED_PROXY_COUNT is 0
-	// (default / direct internet deployment) we deliberately skip the potentially
-	// spoofed X-Forwarded-For header and rely on X-Real-IP only.
-	return (
-		request.headers.get('x-real-ip') ??
-		'unknown'
-	);
+	// No trusted proxy: every forwarding header is attacker-controlled, and honouring one
+	// would turn IP rate limiting into a no-op — rotate the header, get a fresh bucket.
+	// Fall back to the peer address the runtime observed, which no client can set.
+	return request.ip ?? 'unknown';
 }
 
 /**

--- a/src/lib/server/rate-limiter.test.js
+++ b/src/lib/server/rate-limiter.test.js
@@ -27,17 +27,36 @@ describe('trusted proxy parsing', () => {
 		expect(parseTrustedProxyCount(' 01 ')).toBe(1);
 		expect(parseTrustedProxyCount('1abc')).toBe(0);
 		expect(parseTrustedProxyCount('-1')).toBe(0);
-		expect(parseTrustedProxyCount('')).toBe(0);
 	});
 
-	it('does not trust X-Forwarded-For when the proxy count is malformed', () => {
+	it('defaults to one trusted hop when unconfigured', () => {
+		// Every shipped deployment runs behind exactly one platform proxy; a
+		// direct-to-internet deployment has to opt out with an explicit 0.
+		expect(parseTrustedProxyCount(undefined)).toBe(1);
+		expect(parseTrustedProxyCount('')).toBe(1);
+		expect(parseTrustedProxyCount('0')).toBe(0);
+	});
+
+	it('trusts no forwarding header when the proxy count is malformed', () => {
+		// A malformed count must fail closed. Falling back to X-Real-IP here is what
+		// let an attacker rotate the header and mint a fresh rate-limit bucket per
+		// request (GHSA-64m7-3h2w-2qr6).
 		process.env.TRUSTED_PROXY_COUNT = '1abc';
 		const request = requestWithHeaders({
 			'x-forwarded-for': '203.0.113.9, 198.51.100.10',
 			'x-real-ip': '192.0.2.55'
 		});
 
-		expect(getClientIp(request)).toBe('192.0.2.55');
+		expect(getClientIp(request)).toBe('unknown');
+	});
+
+	it('ignores a spoofed X-Real-IP when no proxy is trusted', () => {
+		process.env.TRUSTED_PROXY_COUNT = '0';
+		const first = getClientIp(requestWithHeaders({ 'x-real-ip': '198.51.100.1' }));
+		const second = getClientIp(requestWithHeaders({ 'x-real-ip': '198.51.100.2' }));
+
+		// Rotating the header must not yield a different rate-limit key.
+		expect(first).toBe(second);
 	});
 
 	it('uses the nth trusted hop from the right when configured', () => {

--- a/supabase/migrations/20260816120000_narrow_reads_and_close_participant_injection.sql
+++ b/supabase/migrations/20260816120000_narrow_reads_and_close_participant_injection.sql
@@ -1,0 +1,187 @@
+-- Wave 2 of the 2026-08 security remediation.
+--
+-- Closes the findings that survived wave 1 (#244-#251):
+--
+--   GHSA-7w99-6w89-2926  `users_select_authenticated` was `USING (true)`, so any
+--                        authenticated account -- including a throwaway anonymous
+--                        sign-in -- could read every user's phone_number and salt.
+--   GHSA-vxcr-4mm8-jfm3  `conversation_participants` INSERT only required a non-NULL
+--                        auth.uid(), so anyone could insert themselves into anyone's
+--                        conversation and start receiving its ciphertext stream.
+--   GHSA-9jgr-3h36-9748  `conversations` carried a `FOR SELECT USING (true)` policy
+--                        with no role clause, readable by anon in any fresh deploy.
+--   GHSA-ffpr-xfm2-pp84  `get_inactive_participants` returns participants' full phone
+--                        numbers to any caller that clears the participation check.
+--
+-- Plus the social-graph read tracked as NEW-02: `conversation_participants` was
+-- likewise `FOR SELECT USING (true)`.
+
+-- --------------------------------------------------------------------------
+-- Helpers.
+--
+-- RLS policy expressions evaluate the policies of any table they reference, which
+-- is what produced this schema's long history of "fix recursion" migrations: a
+-- policy on `conversations` that reads `conversation_participants` re-enters a
+-- policy on `conversation_participants` that reads `conversations`. These helpers
+-- are SECURITY DEFINER, so they run as the table owner and bypass RLS, which
+-- breaks the cycle. They are deliberately narrow -- an id and two booleans about
+-- the caller's own membership -- so bypassing RLS inside them leaks nothing the
+-- caller could not already determine.
+-- --------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.current_app_user_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+    SELECT u.id
+    FROM public.users u
+    WHERE u.auth_user_id = auth.uid()
+    LIMIT 1;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.is_conversation_participant(conversation_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.conversation_participants cp
+        WHERE cp.conversation_id = conversation_uuid
+          AND cp.user_id = public.current_app_user_id()
+          AND cp.left_at IS NULL
+    );
+$function$;
+
+CREATE OR REPLACE FUNCTION public.is_conversation_creator(conversation_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.conversations c
+        WHERE c.id = conversation_uuid
+          AND c.created_by = public.current_app_user_id()
+    );
+$function$;
+
+CREATE OR REPLACE FUNCTION public.shares_conversation_with(target_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.conversation_participants mine
+        JOIN public.conversation_participants theirs
+          ON theirs.conversation_id = mine.conversation_id
+        WHERE mine.user_id = public.current_app_user_id()
+          AND theirs.user_id = target_user_id
+    );
+$function$;
+
+-- The default PUBLIC grant is what made 48 SECURITY DEFINER functions anon-executable
+-- in the first place (#247); do not repeat it for these.
+REVOKE EXECUTE ON FUNCTION public.current_app_user_id()                  FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.is_conversation_participant(uuid)      FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.is_conversation_creator(uuid)          FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.shares_conversation_with(uuid)         FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.current_app_user_id()                   TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_conversation_participant(uuid)       TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_conversation_creator(uuid)           TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.shares_conversation_with(uuid)          TO authenticated, service_role;
+
+-- --------------------------------------------------------------------------
+-- GHSA-7w99: narrow the global read of `users`.
+--
+-- The caller may read their own row, and the rows of people they actually share a
+-- conversation with. Directory search needs to reach further than that by design,
+-- so `/api/users/search` was moved to the service role in the same change and
+-- keeps masking phone numbers to ***-***-1234 before returning them.
+-- --------------------------------------------------------------------------
+DROP POLICY IF EXISTS users_select_authenticated ON public.users;
+CREATE POLICY users_select_authenticated ON public.users
+    FOR SELECT TO authenticated
+    USING (
+        auth_user_id = auth.uid()
+        OR public.shares_conversation_with(id)
+    );
+
+-- --------------------------------------------------------------------------
+-- GHSA-9jgr: `conversations` must not be world-readable.
+--
+-- Both of the old policies go: the `USING (true)` one had no role clause at all
+-- (so it reached anon), and `conversations_select_policy` only asked that the
+-- caller be logged in.
+-- --------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can read conversations for participation check" ON public.conversations;
+DROP POLICY IF EXISTS conversations_select_policy                            ON public.conversations;
+DROP POLICY IF EXISTS "Users can read own conversations"                     ON public.conversations;
+
+CREATE POLICY conversations_select_participant ON public.conversations
+    FOR SELECT TO authenticated
+    USING (
+        created_by = public.current_app_user_id()
+        OR public.is_conversation_participant(id)
+    );
+
+-- --------------------------------------------------------------------------
+-- NEW-02: `conversation_participants` was `USING (true)`, exposing the whole
+-- social graph. Restrict reads to conversations the caller is actually in.
+-- --------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can read all participants"        ON public.conversation_participants;
+DROP POLICY IF EXISTS "Users can read conversation participants" ON public.conversation_participants;
+
+CREATE POLICY conversation_participants_select_scoped ON public.conversation_participants
+    FOR SELECT TO authenticated
+    USING (
+        user_id = public.current_app_user_id()
+        OR public.is_conversation_participant(conversation_id)
+    );
+
+-- --------------------------------------------------------------------------
+-- GHSA-vxcr: close the participant-injection primitive.
+--
+-- The old policy's entire check was `auth.uid() IS NOT NULL`, which let any
+-- authenticated user insert an arbitrary (conversation_id, user_id) pair. A
+-- participant list may now only be extended by the conversation's creator or by
+-- someone already in it -- which still covers the create-then-add-participants
+-- flow, since the creator is the one doing the adding.
+-- --------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Authenticated users can add participants"      ON public.conversation_participants;
+DROP POLICY IF EXISTS "Users can add participants to conversations"   ON public.conversation_participants;
+
+CREATE POLICY conversation_participants_insert_scoped ON public.conversation_participants
+    FOR INSERT TO authenticated
+    WITH CHECK (
+        public.is_conversation_creator(conversation_id)
+        OR public.is_conversation_participant(conversation_id)
+    );
+
+-- --------------------------------------------------------------------------
+-- GHSA-ffpr: stop handing participants' phone numbers to client-side callers.
+--
+-- The function legitimately needs the phone number -- it feeds the SMS
+-- notification path -- but its only caller is server-side and runs as the service
+-- role (see createSMSNotificationService(getServiceRoleClient())). Revoking
+-- `authenticated` therefore removes the PII exposure without changing the
+-- signature, the same reasoning applied to delete_encrypted_data_only in #244.
+-- `anon` was already revoked in 20260814030009.
+-- --------------------------------------------------------------------------
+REVOKE EXECUTE ON FUNCTION public.get_inactive_participants(uuid) FROM PUBLIC, anon, authenticated;
+
+COMMENT ON POLICY users_select_authenticated ON public.users IS
+    'Own row, plus users sharing a conversation with the caller. Directory-wide lookups run as service_role.';
+COMMENT ON POLICY conversation_participants_insert_scoped ON public.conversation_participants IS
+    'Only a conversation creator or an existing participant may extend the participant list (GHSA-vxcr-4mm8-jfm3).';


### PR DESCRIPTION
Closes the ten advisories left open after wave 1 (#244–#251). The other six published advisories already carry `Remediation status — fixed` notes from that wave.

## Application

| Advisory | Fix |
|---|---|
| GHSA-9jq8-g7m8-wg4v | `MessageItem` no longer passes raw content to `dangerouslySetInnerHTML`. The sink is currently unreachable (format detection reads fields the library doesn't return), but correcting that naming would have activated stored XSS against every recipient. |
| GHSA-75px-j56m-6cpr | `/admin` no longer serialises autoblog bearer tokens into the RSC payload. Masking in JSX was cosmetic — the full token was in the wire payload. |
| GHSA-xm8x-rpr6-4j7h | `/api/conversations/delete` now deletes only rows the caller owns. The conversation is GC'd once the last participant leaves. |
| GHSA-j2m4-m3w7-w2cq | CoinPay OAuth requires `email_verified` before linking. A missing claim is not a verified claim. |
| GHSA-64m7-3h2w-2qr6 | `getClientIp` reads forwarding headers only when a trusted proxy is configured. |
| GHSA-29hv-86qw-3vx5 | PBKDF2 100k → 600k, backup-PIN scrypt N=16384 → 2^17. |

## Database — `20260816120000`

| Advisory | Fix |
|---|---|
| GHSA-7w99-6w89-2926 | `users_select_authenticated` was `USING (true)` — narrowed to own row + users sharing a conversation. |
| GHSA-vxcr-4mm8-jfm3 | Participant INSERT restricted to the conversation's creator or an existing participant. |
| GHSA-9jgr-3h36-9748 | Dropped the role-less `USING (true)` SELECT on `conversations`. |
| NEW-02 | `conversation_participants` scoped to conversations the caller is in. |
| GHSA-ffpr-xfm2-pp84 | `get_inactive_participants` EXECUTE revoked from `authenticated`. |

## Two things that need a human call

**1. The migration is not applied.** It narrows read access on `users`, `conversations` and `conversation_participants` in production. I verified statically that the routes needing cross-user reach (`/api/users/search`, `/api/users/by-username`) run as the service role — search was moved to it in this PR — but I could not exercise it against a database. Apply to a branch DB first.

**2. `TRUSTED_PROXY_COUNT` now defaults to 1** instead of 0, on the basis that every shipped deployment (railway.toml, Dockerfile) sits behind exactly one platform proxy. A direct-to-internet deployment must now set `0` explicitly. Previously an unset value meant `X-Real-IP` was trusted unconditionally, so rotating that header defeated every rate limiter.

## Verification

- 497 tests pass across 83 files, including new regression coverage for the deletion scoping, the proxy-header handling and the phone-search oracle.
- `pnpm build` clean.
- `pnpm lint` has 1 pre-existing error in `tests/api/auth/send-sms.test.js`, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)