### PR TITLE
fix(db): make the wave-2 policy migration idempotent against production

### DIFF
--- a/supabase/migrations/20260816120000_narrow_reads_and_close_participant_injection.sql
+++ b/supabase/migrations/20260816120000_narrow_reads_and_close_participant_injection.sql
@@ -128,6 +128,10 @@ CREATE POLICY users_select_authenticated ON public.users
 DROP POLICY IF EXISTS "Users can read conversations for participation check" ON public.conversations;
 DROP POLICY IF EXISTS conversations_select_policy                            ON public.conversations;
 DROP POLICY IF EXISTS "Users can read own conversations"                     ON public.conversations;
+-- Production already carries a hand-applied `conversations_select_participant` (the same
+-- out-of-band patching that produced the drift in QRY-01), so this has to drop before it
+-- creates or the migration aborts with 42710 against prod while succeeding on a fresh DB.
+DROP POLICY IF EXISTS conversations_select_participant                       ON public.conversations;
 
 CREATE POLICY conversations_select_participant ON public.conversations
     FOR SELECT TO authenticated
@@ -140,8 +144,9 @@ CREATE POLICY conversations_select_participant ON public.conversations
 -- NEW-02: `conversation_participants` was `USING (true)`, exposing the whole
 -- social graph. Restrict reads to conversations the caller is actually in.
 -- --------------------------------------------------------------------------
-DROP POLICY IF EXISTS "Users can read all participants"        ON public.conversation_participants;
+DROP POLICY IF EXISTS "Users can read all participants"          ON public.conversation_participants;
 DROP POLICY IF EXISTS "Users can read conversation participants" ON public.conversation_participants;
+DROP POLICY IF EXISTS conversation_participants_select_scoped    ON public.conversation_participants;
 
 CREATE POLICY conversation_participants_select_scoped ON public.conversation_participants
     FOR SELECT TO authenticated
@@ -159,8 +164,9 @@ CREATE POLICY conversation_participants_select_scoped ON public.conversation_par
 -- someone already in it -- which still covers the create-then-add-participants
 -- flow, since the creator is the one doing the adding.
 -- --------------------------------------------------------------------------
-DROP POLICY IF EXISTS "Authenticated users can add participants"      ON public.conversation_participants;
-DROP POLICY IF EXISTS "Users can add participants to conversations"   ON public.conversation_participants;
+DROP POLICY IF EXISTS "Authenticated users can add participants"    ON public.conversation_participants;
+DROP POLICY IF EXISTS "Users can add participants to conversations" ON public.conversation_participants;
+DROP POLICY IF EXISTS conversation_participants_insert_scoped       ON public.conversation_participants;
 
 CREATE POLICY conversation_participants_insert_scoped ON public.conversation_participants
     FOR INSERT TO authenticated


### PR DESCRIPTION
Follow-up to #252, found while verifying the migration read-only against prod before applying it.

Production carries a hand-applied `conversations_select_participant` policy that exists in no migration — the same out-of-band patching that produced the QRY-01 drift. `20260816120000` created that policy without dropping it first, so it would have succeeded on a fresh database and **aborted with 42710 against production**, which is the one place it needs to run.

Adds the missing `DROP POLICY IF EXISTS` for that policy, and for the two new `conversation_participants` policies so the migration is re-runnable.

## Prod state confirmed before applying

| Table | Current | Needs narrowing |
|---|---|---|
| `conversations` | `conversations_select_participant`, correctly participant-scoped; no `USING (true)` | No — already patched |
| `users` | `users_select_authenticated` `USING (true)` to `authenticated` | Yes |
| `conversation_participants` | `Users can read all participants` `USING (true)`; `Authenticated users can add participants` INSERT with no ownership check | Yes |

## Cross-user read paths checked

The narrowing only holds if nothing running as the `authenticated` role still needs directory-wide reach:

- `/api/crypto/public-keys` — service role, so new-conversation key fetch is unaffected
- `/api/chat/conversations/[id]/participants` — service role
- `/api/users/by-username` — service role
- `/api/users/search` — moved to service role in #252
- `SupabaseHelpers.getUserProfile` — no callers, dead code
- `SMSNotificationSettings` — own-row UPDATE, governed by UPDATE policies this migration does not touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)