### PR TITLE
feat(settings): add encrypted key download to settings

### DIFF
--- a/src/lib/components/settings/PrivateKeyManager.jsx
+++ b/src/lib/components/settings/PrivateKeyManager.jsx
@@ -25,6 +25,10 @@ export default function PrivateKeyManager() {
   const [importPassword, setImportPassword] = useState('');
   const [importLoading, setImportLoading] = useState(false);
   const [importAndBackup, setImportAndBackup] = useState(false);
+  const [exportPassword, setExportPassword] = useState('');
+  const [confirmExportPassword, setConfirmExportPassword] = useState('');
+  const [showExportPassword, setShowExportPassword] = useState(false);
+  const [exportLoading, setExportLoading] = useState(false);
 
   useEffect(() => {
     if (user) { checkKeys(); checkPin(); checkBackup(); }
@@ -109,6 +113,20 @@ export default function PrivateKeyManager() {
     } finally { setImportLoading(false); }
   }
 
+  async function downloadKeys() {
+    if (exportPassword.length < 6) { setError('Export password must be at least 6 characters'); return; }
+    if (exportPassword !== confirmExportPassword) { setError('Export passwords do not match'); return; }
+    setExportLoading(true); setError(''); setSuccess('');
+    try {
+      const encrypted = await privateKeyManager.exportPrivateKeys(exportPassword);
+      const filename = privateKeyManager.generateExportFilename();
+      privateKeyManager.downloadExportedKeys(encrypted, filename);
+      setExportPassword(''); setConfirmExportPassword('');
+      setSuccess(`Downloaded ${filename} — store it somewhere safe. Without this password the file cannot be recovered.`);
+    } catch (err) { setError(err.message || 'Export failed'); }
+    finally { setExportLoading(false); }
+  }
+
   async function setNewPin() {
     if (!pin || pin !== confirmPin || !/^\d{6,12}$/.test(pin)) { setError('PIN must be 6–12 digits and match'); return; }
     setLoading(true); setError(''); setSuccess('');
@@ -185,6 +203,48 @@ export default function PrivateKeyManager() {
                 <button className="btn btn-primary btn-sm" onClick={restoreKeys} disabled={loading || !restorePin}>{loading ? 'Restoring...' : 'Restore Keys'}</button>
               </div>
             )}
+          </>
+        )}
+      </div>
+
+      <div className="pkm-card">
+        <h4>Download Keys to File</h4>
+        {!hasKeys ? (
+          <p style={{ fontSize: '.8125rem', color: 'var(--color-text-secondary)' }}>
+            No keys on this device yet — generate or restore keys before exporting.
+          </p>
+        ) : (
+          <>
+            <p style={{ fontSize: '.8125rem', color: 'var(--color-text-secondary)', marginBottom: '.75rem' }}>
+              Save an encrypted copy of your private keys as a JSON file. The file is encrypted with the
+              password you choose here — nobody, including us, can recover it if you lose that password.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '.5rem' }}>
+              <input
+                type={showExportPassword ? 'text' : 'password'}
+                value={exportPassword}
+                onChange={(e) => setExportPassword(e.target.value)}
+                placeholder="Password to encrypt the file (min 6 characters)"
+                className="pkm-input"
+              />
+              <input
+                type={showExportPassword ? 'text' : 'password'}
+                value={confirmExportPassword}
+                onChange={(e) => setConfirmExportPassword(e.target.value)}
+                placeholder="Confirm password"
+                className="pkm-input"
+              />
+              <label className="pkm-label">
+                <input type="checkbox" checked={showExportPassword} onChange={(e) => setShowExportPassword(e.target.checked)} /> Show password
+              </label>
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={downloadKeys}
+                disabled={exportLoading || !exportPassword || !confirmExportPassword}
+              >
+                {exportLoading ? 'Preparing download...' : 'Download Encrypted Keys'}
+              </button>
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
## Problem

There was no way to download your encrypted keys from https://qrypt.chat/settings. The Private Keys section offered:

- Import keys **from** a file
- Back up **to** the server (PIN-encrypted)
- Restore **from** the server

…but no export-to-disk. So a user could import a backup file they already had, yet never produce one in the first place.

## Cause

The crypto layer was already complete. `src/lib/crypto/private-key-manager.js` implements `exportPrivateKeys(password)`, `generateExportFilename()`, `supportsFileDownload()` and `downloadExportedKeys()`. `exportPrivateKeys()` was called in three places — all of which PUT the ciphertext to `/api/auth/key-backup`. `downloadExportedKeys()` had zero callers anywhere in the repo. This was a missing button, not a missing feature.

## Change

Adds a **Download Keys to File** card to `PrivateKeyManager.jsx`, placed above the existing import card so export/import read as a pair:

- Password + confirmation, minimum 6 characters, with a show/hide toggle
- Uses the same ChaCha20-Poly1305 + HKDF envelope as the server backup, so a downloaded file is accepted by the existing import flow
- Filename comes from `generateExportFilename()` (`qryptchat-pq-keys-<timestamp>.json`)
- Hidden behind a hint when no keys exist on the device
- Success message names the file and states plainly that the password is unrecoverable

No changes to the crypto layer, and no new API surface — the file is generated and encrypted entirely client-side.

## Verification

- `pnpm build` — clean, `/settings` compiles (8.16 kB)
- `pnpm vitest run tests/` — 30 files, 295 tests, all passing
- `oxlint` on the changed file — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)