### PR TITLE
fix(ui): hide the feedback FAB on chat routes

### DIFF
--- a/src/app/client-layout.jsx
+++ b/src/app/client-layout.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { FeedbackWidget } from '@profullstack/stack/feedback';
 import { useThemeStore, themeUtils } from '@/lib/stores/theme.js';
 import { useI18n } from '@/lib/hooks/useI18n.js';
 import { i18nUtils, languages } from '@/lib/stores/i18n.js';
@@ -62,6 +63,14 @@ export default function ClientLayout({ children }) {
           <ActiveCallInterface />
         </>
       )}
+      {/* pathname is passed explicitly so hideOnRoutes tracks client-side
+          navigation — the widget's own detection only reads window.location
+          on first render, which never re-runs from a root layout. */}
+      <FeedbackWidget
+        property="qrypt.chat"
+        pathname={pathname}
+        hideOnRoutes={['/chat', '/chats', '/u', '/anon']}
+      />
       <style>{`
         .app {
           min-height: 100vh;

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,6 +1,5 @@
 import './globals.css';
 import ClientLayout from './client-layout.jsx';
-import { FeedbackWidget } from '@profullstack/stack/feedback';
 import Script from "next/script";
 
 const SITE_URL = (process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://qrypt.chat').replace(/\/$/, '');
@@ -145,7 +144,7 @@ export default function RootLayout({ children }) {
       <body suppressHydrationWarning>
         <ClientLayout>{children}</ClientLayout>
               <Script data-site="38c4083a-a35e-435d-8a0e-3510c465f419" src="https://crawlproof.com/stats.js" strategy="afterInteractive" />
-      <FeedbackWidget property="qrypt.chat" hideOnRoutes={['/chat', '/chats', '/u', '/anon']} /></body>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
The feedback button was covering the message submit button in the chat window.

## Why it wasn't already hidden

`hideOnRoutes={['/chat', '/chats', '/u', '/anon']}` was already set, but the widget was mounted from the **server** root layout (`src/app/layout.jsx`). Without an explicit `pathname` prop, `FeedbackWidget` falls back to reading `window.location.pathname` during render — and a root layout never re-renders on client-side navigation. So the route check only ran once, on initial load: navigate from `/` into a conversation and the FAB stayed up.

## Fix

Move the widget into `ClientLayout`, which already calls `usePathname()`, and pass it through explicitly. The widget's own docs call this out as the supported way to make `hideOnRoutes` track SPA navigation. Same property, same route list — only where it's mounted changes.

## Verification

- `pnpm build` compiles and type-checks both changed files.
- The build then fails at page-data collection with `supabaseUrl is required` for `/api/auth/key-backup` — verified pre-existing by stashing the change and rebuilding: identical failure. It's a missing-env artifact of building without secrets, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)